### PR TITLE
feat: add Calls for Help housekeeping page with status tracking

### DIFF
--- a/Areas/Housekeeping/Controllers/CallsForHelpController.cs
+++ b/Areas/Housekeeping/Controllers/CallsForHelpController.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using KeplerCMS.Filters;
+using KeplerCMS.Models;
+using KeplerCMS.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KeplerCMS.Areas.Housekeeping
+{
+    [Area("Housekeeping")]
+    public class CallsForHelpController : Controller
+    {
+        private readonly ICallsForHelpService _callsForHelpService;
+
+        public CallsForHelpController(ICallsForHelpService callsForHelpService)
+        {
+            _callsForHelpService = callsForHelpService;
+        }
+
+        [HousekeepingFilter(Fuse.fuse_receive_calls_for_help)]
+        public async Task<IActionResult> Index(string date)
+        {
+            var filterDate = string.IsNullOrEmpty(date) 
+                ? DateTime.Today 
+                : DateTime.Parse(date);
+
+            var calls = await _callsForHelpService.GetByDate(filterDate);
+
+            ViewBag.FilterDate = filterDate;
+            return View(calls);
+        }
+    }
+}

--- a/Areas/Housekeeping/Views/CallsForHelp/Index.cshtml
+++ b/Areas/Housekeeping/Views/CallsForHelp/Index.cshtml
@@ -1,0 +1,151 @@
+@using KeplerCMS.Data.Models
+@model IEnumerable<CallsForHelp>
+@{
+    ViewData["Title"] = "Calls for Help";
+    var filterDate = (DateTime)ViewBag.FilterDate;
+}
+
+<h2>Results on @filterDate.ToString("yyyy-MM-dd")</h2>
+
+<form method="get" style="margin-bottom: 10px;">
+    <label for="date">Filter by date:</label>
+    <input type="date" id="date" name="date" value="@filterDate.ToString("yyyy-MM-dd")" />
+    <button type="submit">Filter</button>
+</form>
+
+@if (Model.Any())
+{
+    <table class="habboTable">
+        <thead>
+            <tr>
+                <th>Caller</th>
+                <th>Time</th>
+                <th>Room name</th>
+                <th>Category</th>
+                <th>Message</th>
+                <th>Picked by</th>
+                <th>Time picked</th>
+                <th>Status</th>
+                <th>Chat Log</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var call in Model)
+            {
+                var rowClass = call.Category == 1 ? "cfh-emergency" : call.Category == 3 ? "cfh-automatic" : "";
+                <tr class="@rowClass">
+                    <td>
+                        <a href="@Url.Action("Manage", "Users", new { id = call.CallerId })">@call.CallerUsername</a>
+                        <a href="@Url.Action("Manage", "Users", new { id = call.CallerId })">[?]</a>
+                    </td>
+                    <td>@call.CreatedAt.ToString("yyyy-MM-dd HH:mm")</td>
+                    <td>@call.RoomName</td>
+                    <td>
+                        @switch (call.Category)
+                        {
+                            case 1:
+                                <span>Emergency</span>
+                                break;
+                            case 2:
+                                <span>Normal</span>
+                                break;
+                            case 3:
+                                <span>Automatic</span>
+                                break;
+                        }
+                    </td>
+                    <td>@call.Message</td>
+                    <td>
+                        @if (call.PickedUpBy > 0)
+                        {
+                            <a href="@Url.Action("Manage", "Users", new { id = call.PickedUpBy })">@call.PickedUpUsername</a>
+                        }
+                        else
+                        {
+                            <span>-</span>
+                        }
+                    </td>
+                    <td>
+                        @if (call.PickedUpAt.HasValue)
+                        {
+                            @call.PickedUpAt.Value.ToString("yyyy-MM-dd HH:mm")
+                        }
+                        else
+                        {
+                            <span>-</span>
+                        }
+                    </td>
+                    <td>
+                        @if (!string.IsNullOrEmpty(call.ClosedReason))
+                        {
+                            switch (call.ClosedReason)
+                            {
+                                case "replied":
+                                    <span class="cfh-status-replied" title="@call.ReplyMessage">&#x2709;</span>
+                                    break;
+                                case "cancelled":
+                                    <span class="cfh-status-cancelled" title="Cancelled by caller">&#x2715;</span>
+                                    break;
+                                case "expired":
+                                    <span class="cfh-status-expired" title="Expired without response">&#x23F0;</span>
+                                    break;
+                            }
+                        }
+                        else if (call.PickedUpBy > 0)
+                        {
+                            <span class="cfh-status-progress" title="In progress">&#x270E;</span>
+                        }
+                        else
+                        {
+                            <span class="cfh-status-open" title="Open">&#x25CF;</span>
+                        }
+                    </td>
+                    <td>
+                        @if (call.RoomId > 0)
+                        {
+                            <a href="@Url.Action("View", "Rooms", new { id = call.RoomId })">Chat Log</a>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <p>No calls for help found for this date.</p>
+}
+
+<style>
+    tr.cfh-emergency td {
+        background-color: #FFCC00 !important;
+    }
+    tr.cfh-automatic td {
+        background-color: #FFD700 !important;
+    }
+    .cfh-status-replied {
+        color: #006600;
+        font-size: 16px;
+        cursor: help;
+    }
+    .cfh-status-cancelled {
+        color: #999999;
+        font-size: 16px;
+        cursor: help;
+    }
+    .cfh-status-expired {
+        color: #CC0000;
+        font-size: 16px;
+        cursor: help;
+    }
+    .cfh-status-progress {
+        color: #FF6600;
+        font-size: 16px;
+        cursor: help;
+    }
+    .cfh-status-open {
+        color: #FF6600;
+        font-size: 16px;
+        cursor: help;
+    }
+</style>

--- a/Areas/Housekeeping/Views/Shared/_Housekeeping.cshtml
+++ b/Areas/Housekeeping/Views/Shared/_Housekeeping.cshtml
@@ -32,6 +32,7 @@
         { "/housekeeping/auditlog", HousekeepingMenu.AdminTools },
         { "/housekeeping/bots", HousekeepingMenu.AdminTools },
         { "/housekeeping/rewards", HousekeepingMenu.AdminTools },
+        { "/housekeeping/callsforhelp", HousekeepingMenu.HobbaTools },
     };
 
     foreach (var key in menuMapping.Keys.Where(key => path.ToString().Contains(key) || path == key))
@@ -154,6 +155,20 @@
                             <div class="container-content">
                                 <ul>
                                     @await menuHelper.Render("User search & information tool", Url.Action("Index", "Users"), new List<Fuse> { Fuse.fuse_kick })
+                                </ul>
+                            </div>
+                        </div>
+                    }
+
+                    @if (HousekeepingAccess.HasAccess(userFuses, new List<Fuse> { Fuse.fuse_receive_calls_for_help }))
+                    {
+                        <div class="container">
+                            <div class="title">
+                                Customer service
+                            </div>
+                            <div class="container-content">
+                                <ul>
+                                    @await menuHelper.Render("Calls for help", Url.Action("Index", "CallsForHelp"), new List<Fuse> { Fuse.fuse_receive_calls_for_help })
                                 </ul>
                             </div>
                         </div>

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -104,6 +104,7 @@ namespace KeplerCMS.Data
         public DbSet<RankBadges> RankBadges { get; set; }
         public DbSet<UsersBans> UsersBans { get; set; }
         public DbSet<AuditLog> AuditLogs { get; set; }
+        public DbSet<CallsForHelp> CallsForHelp { get; set; }
         public DataContext(DbContextOptions<DataContext> options)
             : base(options) { }
     }

--- a/Data/Models/CallsForHelp.cs
+++ b/Data/Models/CallsForHelp.cs
@@ -1,0 +1,40 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace KeplerCMS.Data.Models
+{
+    [Table("calls_for_help")]
+    public class CallsForHelp
+    {
+        [Key]
+        [Column("id")]
+        public int Id { get; set; }
+        [Column("caller_id")]
+        public int CallerId { get; set; }
+        [Column("caller_username")]
+        public string CallerUsername { get; set; }
+        [Column("message")]
+        public string Message { get; set; }
+        [Column("room_id")]
+        public int RoomId { get; set; }
+        [Column("room_name")]
+        public string RoomName { get; set; }
+        [Column("category")]
+        public int Category { get; set; }
+        [Column("picked_up_by")]
+        public int PickedUpBy { get; set; }
+        [Column("picked_up_username")]
+        public string PickedUpUsername { get; set; }
+        [Column("picked_up_at")]
+        public DateTime? PickedUpAt { get; set; }
+        [Column("closed_at")]
+        public DateTime? ClosedAt { get; set; }
+        [Column("closed_reason")]
+        public string ClosedReason { get; set; }
+        [Column("reply_message")]
+        public string ReplyMessage { get; set; }
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Models/Enums/Fuse.cs
+++ b/Models/Enums/Fuse.cs
@@ -46,7 +46,9 @@ namespace KeplerCMS.Models
         [Description("fuse_see_chat_log_link")]
         fuse_see_chat_log_link,
         [Description("fuse_bots")]
-        fuse_bots
+        fuse_bots,
+        [Description("fuse_receive_calls_for_help")]
+        fuse_receive_calls_for_help
         
     }
 }

--- a/Services/Implementations/CallsForHelpService.cs
+++ b/Services/Implementations/CallsForHelpService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using KeplerCMS.Data;
+using KeplerCMS.Data.Models;
+using KeplerCMS.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace KeplerCMS.Services.Implementations
+{
+    public class CallsForHelpService : ICallsForHelpService
+    {
+        private readonly DataContext _context;
+
+        public CallsForHelpService(DataContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<CallsForHelp>> GetByDate(DateTime date)
+        {
+            return await _context.CallsForHelp
+                .Where(c => c.CreatedAt.Date == date.Date)
+                .OrderByDescending(c => c.CreatedAt)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<CallsForHelp>> GetPending()
+        {
+            return await _context.CallsForHelp
+                .Where(c => c.PickedUpBy == 0)
+                .OrderByDescending(c => c.CreatedAt)
+                .ToListAsync();
+        }
+    }
+}

--- a/Services/Interfaces/ICallsForHelpService.cs
+++ b/Services/Interfaces/ICallsForHelpService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using KeplerCMS.Data.Models;
+
+namespace KeplerCMS.Services.Interfaces
+{
+    public interface ICallsForHelpService
+    {
+        Task<IEnumerable<CallsForHelp>> GetByDate(DateTime date);
+        Task<IEnumerable<CallsForHelp>> GetPending();
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -120,6 +120,7 @@ namespace KeplerCMS
             services.AddScoped<IAuditLogService, AuditLogService>();
             services.AddScoped<IFurniService, FurniService>();
             services.AddScoped<IBotService, BotService>();
+            services.AddScoped<ICallsForHelpService, CallsForHelpService>();
 
             services.AddMjmlServices(o =>
             {


### PR DESCRIPTION
- Controller with date filter for browsing CFH history
- Service layer querying calls_for_help table
- Model with full DB mapping (caller, room, category, picked_up, closed_at, closed_reason, reply_message)
- Status column with unicode icons: open, in progress, replied (with reply tooltip), cancelled, expired
- Category color coding (emergency=yellow)
- Chat log link pointing to /housekeeping/rooms/view/{roomId}
- Sidebar navigation under Customer service section
- Removed broken Room chat logs sidebar link
- Added fuse_receive_calls_for_help permission