### PR TITLE
feat: campaign management + scheduled visibility for containers/promo…

### DIFF
--- a/Areas/Housekeeping/Controllers/CampaignsController.cs
+++ b/Areas/Housekeeping/Controllers/CampaignsController.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Areas.Housekeeping.Models.Views;
+using KeplerCMS.Data.Models;
+using KeplerCMS.Filters;
+using KeplerCMS.Models;
+using KeplerCMS.Models.Enums;
+using KeplerCMS.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace KeplerCMS.Areas.Housekeeping
+{
+    [Area("Housekeeping")]
+    public class CampaignsController : Controller
+    {
+        private readonly ICampaignService _campaignService;
+        private readonly ICampaignExecutor _campaignExecutor;
+        private readonly ICatalogueService _catalogueService;
+        private readonly IRoomService _roomService;
+        private readonly IAuditLogService _auditService;
+
+        public CampaignsController(
+            ICampaignService campaignService,
+            ICampaignExecutor campaignExecutor,
+            ICatalogueService catalogueService,
+            IRoomService roomService,
+            IAuditLogService auditService)
+        {
+            _campaignService = campaignService;
+            _campaignExecutor = campaignExecutor;
+            _catalogueService = catalogueService;
+            _roomService = roomService;
+            _auditService = auditService;
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        public async Task<IActionResult> Index(string message = null)
+        {
+            var campaigns = await _campaignService.GetAll();
+            var viewModel = new CampaignListViewModel
+            {
+                Campaigns = campaigns,
+                Message = message
+            };
+            return View(viewModel);
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        public async Task<IActionResult> Create()
+        {
+            return View();
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> Create(CampaignCreateModel model)
+        {
+            if (string.IsNullOrWhiteSpace(model.Name))
+            {
+                ModelState.AddModelError("Name", "Name is required");
+                return View(model);
+            }
+
+            var campaign = new Campaign
+            {
+                Name = model.Name,
+                Description = model.Description,
+                StartDate = model.StartDate,
+                EndDate = model.EndDate,
+                CreatedById = int.Parse(HttpContext.User.Identity.Name)
+            };
+
+            await _campaignService.Create(campaign);
+            return RedirectToAction("Edit", new { id = campaign.Id });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        public async Task<IActionResult> Edit(int id, string message = null)
+        {
+            var campaign = await _campaignService.GetById(id);
+            if (campaign == null)
+                return RedirectToAction("Index", new { message = "Campaign not found" });
+
+            var viewModel = new CampaignEditViewModel
+            {
+                Campaign = campaign,
+                AllCataloguePages = (await _catalogueService.GetCataloguePages()).ToList(),
+                PublicRooms = await _roomService.GetPublicRooms(),
+                Message = message
+            };
+
+            return View(viewModel);
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> Update(CampaignUpdateModel model)
+        {
+            var campaign = await _campaignService.GetById(model.Id);
+            if (campaign == null)
+                return RedirectToAction("Index", new { message = "Campaign not found" });
+
+            if (campaign.StatusEnum == CampaignStatus.Active)
+                return RedirectToAction("Edit", new { id = model.Id, message = "Cannot edit an active campaign" });
+
+            campaign.Name = model.Name;
+            campaign.Description = model.Description;
+            campaign.StartDate = model.StartDate;
+            campaign.EndDate = model.EndDate;
+
+            // Update status based on dates
+            if (campaign.StartDate.HasValue && campaign.StartDate.Value > DateTime.Now)
+            {
+                campaign.StatusEnum = CampaignStatus.Scheduled;
+            }
+            else if (campaign.StatusEnum == CampaignStatus.Scheduled && (!campaign.StartDate.HasValue || campaign.StartDate.Value <= DateTime.Now))
+            {
+                campaign.StatusEnum = CampaignStatus.Draft;
+            }
+
+            await _campaignService.Update(campaign);
+            return RedirectToAction("Edit", new { id = model.Id, message = "Campaign updated" });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> AddAction(AddActionModel model)
+        {
+            var campaign = await _campaignService.GetById(model.CampaignId);
+            if (campaign == null)
+                return RedirectToAction("Index", new { message = "Campaign not found" });
+
+            if (campaign.StatusEnum == CampaignStatus.Active)
+                return RedirectToAction("Edit", new { id = model.CampaignId, message = "Cannot modify an active campaign" });
+
+            var maxOrder = campaign.Actions.Any() ? campaign.Actions.Max(a => a.OrderIndex) : 0;
+
+            var action = new CampaignAction
+            {
+                CampaignId = model.CampaignId,
+                ActionType = model.ActionType,
+                ActionData = model.ActionData,
+                OrderIndex = maxOrder + 1
+            };
+
+            await _campaignService.AddAction(action);
+            return RedirectToAction("Edit", new { id = model.CampaignId, message = "Action added" });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> UpdateAction(EditActionModel model)
+        {
+            var campaign = await _campaignService.GetById(model.CampaignId);
+            if (campaign == null)
+                return RedirectToAction("Index", new { message = "Campaign not found" });
+
+            if (campaign.StatusEnum == CampaignStatus.Active)
+                return RedirectToAction("Edit", new { id = model.CampaignId, message = "Cannot modify an active campaign" });
+
+            var action = campaign.Actions.FirstOrDefault(a => a.Id == model.ActionId);
+            if (action == null)
+                return RedirectToAction("Edit", new { id = model.CampaignId, message = "Action not found" });
+
+            action.ActionData = model.ActionData;
+            await _campaignService.UpdateAction(action);
+            return RedirectToAction("Edit", new { id = model.CampaignId, message = "Action updated" });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> RemoveAction(int actionId, int campaignId)
+        {
+            var campaign = await _campaignService.GetById(campaignId);
+            if (campaign?.StatusEnum == CampaignStatus.Active)
+                return RedirectToAction("Edit", new { id = campaignId, message = "Cannot modify an active campaign" });
+
+            await _campaignService.RemoveAction(actionId);
+            return RedirectToAction("Edit", new { id = campaignId, message = "Action removed" });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> Activate(int id)
+        {
+            var campaign = await _campaignService.GetById(id);
+            if (campaign == null)
+                return RedirectToAction("Index", new { message = "Campaign not found" });
+
+            if (!campaign.Actions.Any())
+                return RedirectToAction("Edit", new { id, message = "Campaign has no actions to activate" });
+
+            await _campaignExecutor.ActivateCampaign(id);
+            return RedirectToAction("Edit", new { id, message = "Campaign activated successfully" });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> Deactivate(int id)
+        {
+            await _campaignExecutor.DeactivateCampaign(id);
+            return RedirectToAction("Edit", new { id, message = "Campaign deactivated - changes reverted" });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> Clone(CloneCampaignModel model)
+        {
+            if (string.IsNullOrWhiteSpace(model.NewName))
+                return RedirectToAction("Index", new { message = "Please provide a name for the cloned campaign" });
+
+            var userId = int.Parse(HttpContext.User.Identity.Name);
+            var cloned = await _campaignService.Clone(model.CampaignId, model.NewName, userId);
+            if (cloned == null)
+                return RedirectToAction("Index", new { message = "Failed to clone campaign" });
+
+            return RedirectToAction("Edit", new { id = cloned.Id, message = "Campaign cloned successfully" });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpPost]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _campaignService.Delete(id);
+            if (!result)
+                return RedirectToAction("Index", new { message = "Cannot delete an active campaign" });
+
+            return RedirectToAction("Index", new { message = "Campaign deleted" });
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpGet]
+        public async Task<IActionResult> GetCataloguePages()
+        {
+            var pages = await _catalogueService.GetCataloguePages();
+            return Json(pages.Select(p => new { p.Id, p.Name, p.NameIndex, Visible = p.IndexVisible == 1 }));
+        }
+
+        [HousekeepingFilter(Fuse.fuse_campaigns)]
+        [HttpGet]
+        public async Task<IActionResult> GetPublicRooms()
+        {
+            var rooms = await _roomService.GetPublicRooms();
+            return Json(rooms.Select(r => new { r.Id, r.Name, r.Casts }));
+        }
+    }
+}

--- a/Areas/Housekeeping/Controllers/MenuController.cs
+++ b/Areas/Housekeeping/Controllers/MenuController.cs
@@ -57,7 +57,7 @@ namespace KeplerCMS.Areas.Housekeeping
         public async Task<IActionResult> Update(int id)
         {
             var menu = await _menuService.Get(id);
-            return View(new MenuUpdateViewModel{ Id = menu.Id, Href = menu.Href, Icon = menu.Icon, State = menu.State, Text = menu.Text });
+            return View(new MenuUpdateViewModel{ Id = menu.Id, Href = menu.Href, Icon = menu.Icon, State = menu.State, Text = menu.Text, StartDate = menu.StartDate, EndDate = menu.EndDate });
         }
 
         [HousekeepingFilter(Fuse.housekeeping_menu)]

--- a/Areas/Housekeeping/Controllers/PagesController.cs
+++ b/Areas/Housekeeping/Controllers/PagesController.cs
@@ -98,7 +98,7 @@ namespace KeplerCMS.Areas.Housekeeping
         public async Task<IActionResult> UpdateContainer(int id)
         {
             var details = await _pageService.GetContainerById(id);
-            return View(new ContainerUpdateViewModel { Id = details.Id, Title = details.Title, Text = details.Text, Theme = details.Theme, Type = details.Type, PageId = details.PageId, Hidden = details.Hidden });
+            return View(new ContainerUpdateViewModel { Id = details.Id, Title = details.Title, Text = details.Text, Theme = details.Theme, Type = details.Type, PageId = details.PageId, Hidden = details.Hidden, StartDate = details.StartDate, EndDate = details.EndDate });
         }
 
         [HousekeepingFilter(Fuse.housekeeping_pages)]

--- a/Areas/Housekeeping/Models/Views/CampaignViewModels.cs
+++ b/Areas/Housekeeping/Models/Views/CampaignViewModels.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using KeplerCMS.Data.Models;
+using KeplerCMS.Models.Enums;
+
+namespace KeplerCMS.Areas.Housekeeping.Models.Views
+{
+    public class CampaignListViewModel
+    {
+        public List<Campaign> Campaigns { get; set; }
+        public string Message { get; set; }
+    }
+
+    public class CampaignEditViewModel
+    {
+        public Campaign Campaign { get; set; }
+        public List<CataloguePages> AllCataloguePages { get; set; }
+        public List<Rooms> PublicRooms { get; set; }
+        public string Message { get; set; }
+    }
+
+    public class CampaignCreateModel
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+    }
+
+    public class CampaignUpdateModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+    }
+
+    public class AddActionModel
+    {
+        public int CampaignId { get; set; }
+        public string ActionType { get; set; }
+        public string ActionData { get; set; }
+    }
+
+    public class EditActionModel
+    {
+        public int ActionId { get; set; }
+        public int CampaignId { get; set; }
+        public string ActionData { get; set; }
+    }
+
+    public class CloneCampaignModel
+    {
+        public int CampaignId { get; set; }
+        public string NewName { get; set; }
+    }
+}

--- a/Areas/Housekeeping/Models/Views/ContainerViewModel.cs
+++ b/Areas/Housekeeping/Models/Views/ContainerViewModel.cs
@@ -21,6 +21,8 @@ namespace KeplerCMS.Areas.Housekeeping.Models.Views
         [Required]
         public string Theme { get; set; }
         public bool Hidden { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
     }
     public class ContainerUpdateViewModel
     {
@@ -38,5 +40,7 @@ namespace KeplerCMS.Areas.Housekeeping.Models.Views
         public string Theme { get; set; }
 
         public bool Hidden { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
     }
 }

--- a/Areas/Housekeeping/Models/Views/MenuViewModel.cs
+++ b/Areas/Housekeeping/Models/Views/MenuViewModel.cs
@@ -16,6 +16,8 @@ namespace KeplerCMS.Areas.Housekeeping.Models.Views
         public string Href { get; set; }
         [Required]
         public string State { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
     }
     public class MenuUpdateViewModel
     {
@@ -29,6 +31,8 @@ namespace KeplerCMS.Areas.Housekeeping.Models.Views
         public string Href { get; set; }
         [Required]
         public string State { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
     }
 
     public class MenuReArrangeModel

--- a/Areas/Housekeeping/Views/Campaigns/Create.cshtml
+++ b/Areas/Housekeeping/Views/Campaigns/Create.cshtml
@@ -1,0 +1,50 @@
+@model KeplerCMS.Areas.Housekeeping.Models.Views.CampaignCreateModel
+
+<div class="card">
+    <div class="card-header">
+        <h4 class="text-uppercase">Create Campaign</h4>
+    </div>
+    <div class="card-body">
+        <form asp-action="Create">
+            <div class="form-group">
+                <label class="label-control">Name</label>
+                <input asp-for="Name" class="form-control" placeholder="e.g. Christmas 2025" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Description</label>
+                <textarea asp-for="Description" class="form-control" rows="3" placeholder="Optional notes about this campaign"></textarea>
+            </div>
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="form-group">
+                        <label class="label-control">Start Date (optional - leave empty for manual activation)</label>
+                        <input asp-for="StartDate" id="startDatepicker" type="text" class="form-control" />
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="form-group">
+                        <label class="label-control">End Date (optional - leave empty for manual deactivation)</label>
+                        <input asp-for="EndDate" id="endDatepicker" type="text" class="form-control" />
+                    </div>
+                </div>
+            </div>
+            <div class="form-group">
+                <button type="submit" class="btn btn-sm btn-primary">Create Campaign</button>
+                <a href="@Url.Action("Index")" class="btn btn-sm btn-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section scripts {
+    <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
+    <script>
+        $(document).ready(function () {
+            var datetimeSettings = { format: 'Y-m-d H:i:s' };
+            $("#startDatepicker").datetimepicker(datetimeSettings);
+            $("#endDatepicker").datetimepicker(datetimeSettings);
+        });
+    </script>
+}

--- a/Areas/Housekeeping/Views/Campaigns/Edit.cshtml
+++ b/Areas/Housekeeping/Views/Campaigns/Edit.cshtml
@@ -1,0 +1,576 @@
+@model KeplerCMS.Areas.Housekeeping.Models.Views.CampaignEditViewModel
+@using KeplerCMS.Models.Enums
+
+@{
+    var campaign = Model.Campaign;
+    var isActive = campaign.StatusEnum == CampaignStatus.Active;
+    var isDraft = campaign.StatusEnum == CampaignStatus.Draft || campaign.StatusEnum == CampaignStatus.Scheduled;
+}
+
+<h1>Campaign: @campaign.Name</h1>
+
+@if (!string.IsNullOrEmpty(Model.Message))
+{
+    <div class="message">@Model.Message</div>
+}
+
+<div class="row">
+    <div class="col-md-8">
+        <!-- Campaign Details -->
+        <div class="card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h4 class="text-uppercase mb-0">Campaign Details</h4>
+                <span class="badge @(campaign.Status switch { "active" => "badge-success", "scheduled" => "badge-info", "ended" => "badge-secondary", _ => "badge-warning" })">
+                    @campaign.Status
+                </span>
+            </div>
+            <div class="card-body">
+                <form asp-action="Update" method="post">
+                    <input type="hidden" name="Id" value="@campaign.Id" />
+                    <div class="form-group">
+                        <label class="label-control">Name</label>
+                        <input name="Name" class="form-control" value="@campaign.Name" @(isActive ? "disabled" : "") />
+                    </div>
+                    <div class="form-group">
+                        <label class="label-control">Description</label>
+                        <textarea name="Description" class="form-control" rows="2" @(isActive ? "disabled" : "")>@campaign.Description</textarea>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label class="label-control">Start Date</label>
+                                <input name="StartDate" id="startDatepicker" type="text" class="form-control"
+                                       value="@(campaign.StartDate?.ToString("yyyy-MM-dd HH:mm:ss"))" @(isActive ? "disabled" : "") />
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="form-group">
+                                <label class="label-control">End Date</label>
+                                <input name="EndDate" id="endDatepicker" type="text" class="form-control"
+                                       value="@(campaign.EndDate?.ToString("yyyy-MM-dd HH:mm:ss"))" @(isActive ? "disabled" : "") />
+                            </div>
+                        </div>
+                    </div>
+                    @if (!isActive)
+                    {
+                        <button type="submit" class="btn btn-sm btn-primary">Save Changes</button>
+                    }
+                </form>
+            </div>
+        </div>
+
+        <!-- Actions List -->
+        <div class="card mb-3">
+            <div class="card-header">
+                <h4 class="text-uppercase">Actions (@campaign.Actions.Count)</h4>
+            </div>
+            <div class="card-body">
+                @if (campaign.Actions.Any())
+                {
+                    <table class="blueTable">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Type</th>
+                                <th>Summary</th>
+                                <th>Operations</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var action in campaign.Actions.OrderBy(a => a.OrderIndex))
+                            {
+                                <tr>
+                                    <td>@action.OrderIndex</td>
+                                    <td><span class="badge badge-primary">@action.ActionType</span></td>
+                                    <td>@GetActionSummary(action)</td>
+                                    <td>
+                                        @if (!isActive)
+                                        {
+                                            <button type="button" class="btn btn-sm btn-info edit-action-btn"
+                                                    data-action-id="@action.Id"
+                                                    data-action-type="@action.ActionType"
+                                                    data-action-data="@action.ActionData">Edit</button>
+                                            <form asp-action="RemoveAction" method="post" style="display:inline;">
+                                                <input type="hidden" name="actionId" value="@action.Id" />
+                                                <input type="hidden" name="campaignId" value="@campaign.Id" />
+                                                <button type="submit" class="btn btn-sm btn-danger"
+                                                        onclick="return confirm('Remove this action?')">Remove</button>
+                                            </form>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+                else
+                {
+                    <p class="text-muted">No actions configured yet. Add actions below.</p>
+                }
+            </div>
+        </div>
+
+        <!-- Add Action -->
+        @if (!isActive)
+        {
+            <div class="card mb-3">
+                <div class="card-header">
+                    <h4 class="text-uppercase" id="actionCardTitle">Add Action</h4>
+                </div>
+                <div class="card-body">
+                    <div id="editModeBanner" class="alert alert-info" style="display:none;">
+                        Editing existing action — <a href="#" onclick="cancelEdit(); return false;">cancel and add a new action instead</a>
+                    </div>
+                    <div class="form-group">
+                        <label class="label-control">Action Type</label>
+                        <select id="actionTypeSelect" class="form-control" onchange="showActionForm()">
+                            <option value="">-- Select action type --</option>
+                            <option value="ChangeBackground">Change Background</option>
+                            <option value="ChangeBanner">Change Banner</option>
+                            <option value="CreateNews">Create News Article</option>
+                            <option value="CataloguePageVisibility">Catalogue Page Visibility</option>
+                            <option value="RoomCcts">Room CCTs</option>
+                        </select>
+                    </div>
+
+                    <!-- Background Form -->
+                    <div id="form-ChangeBackground" class="action-form" style="display:none;">
+                        <div class="form-group">
+                            <label class="label-control">Background Value</label>
+                            <input id="bg-value" class="form-control" placeholder="e.g. christmas_bg" />
+                        </div>
+                        <button class="btn btn-sm btn-success action-submit-btn" onclick="submitAction('ChangeBackground')">Add Action</button>
+                    </div>
+
+                    <!-- Banner Form -->
+                    <div id="form-ChangeBanner" class="action-form" style="display:none;">
+                        <div class="form-group">
+                            <label class="label-control">Banner Value</label>
+                            <input id="banner-value" class="form-control" placeholder="e.g. christmas_banner" />
+                        </div>
+                        <button class="btn btn-sm btn-success action-submit-btn" onclick="submitAction('ChangeBanner')">Add Action</button>
+                    </div>
+
+                    <!-- News Form -->
+                    <div id="form-CreateNews" class="action-form" style="display:none;">
+                        <div class="form-group">
+                            <label class="label-control">Title</label>
+                            <input id="news-title" class="form-control" placeholder="News article title" />
+                        </div>
+                        <div class="form-group">
+                            <label class="label-control">Slug</label>
+                            <input id="news-slug" class="form-control" placeholder="url-friendly-slug" />
+                        </div>
+                        <div class="form-group">
+                            <label class="label-control">Teaser</label>
+                            <input id="news-teaser" class="form-control" placeholder="Short description" />
+                        </div>
+                        <div class="form-group">
+                            <label class="label-control">Writer</label>
+                            <input id="news-writer" class="form-control" placeholder="Author name" />
+                        </div>
+                        <div class="form-group">
+                            <label class="label-control">Body</label>
+                            <textarea id="news-text" class="form-control" rows="5" placeholder="Full article HTML"></textarea>
+                        </div>
+                        <button class="btn btn-sm btn-success action-submit-btn" onclick="submitAction('CreateNews')">Add Action</button>
+                    </div>
+
+                    <!-- Catalogue Visibility Form -->
+                    <div id="form-CataloguePageVisibility" class="action-form" style="display:none;">
+                        <p class="text-muted">Select pages and configure their visibility when this campaign is active. The fuse controls who can see the page (DEFAULT = everyone).</p>
+                        <table class="blueTable">
+                            <thead>
+                                <tr>
+                                    <th>Select</th>
+                                    <th>Page</th>
+                                    <th>Current Fuse</th>
+                                    <th>New Fuse</th>
+                                    <th>Order</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var catPage in Model.AllCataloguePages.OrderBy(p => p.OrderId).ThenBy(p => p.Id))
+                                {
+                                    <tr>
+                                        <td><input type="checkbox" class="catalogue-page-check" data-page-id="@catPage.Id" /></td>
+                                        <td>@catPage.Name (@catPage.NameIndex)</td>
+                                        <td><code>@catPage.Fuse</code></td>
+                                        <td>
+                                            <select class="form-control form-control-sm cat-fuse" data-page-id="@catPage.Id" data-current="@catPage.Fuse">
+                                                <option value="DEFAULT">DEFAULT (visible to all)</option>
+                                                <option value="fuse_catalogue_administrator">Admin only (hidden)</option>
+                                                <option value="fuse_catalogue_clubshop">Club shop</option>
+                                                <option value="fuse_catalogue_habboclub">Habbo Club</option>
+                                                <option value="fuse_catalogue_trophies">Trophies</option>
+                                                <option value="fuse_catalogue_xmas">Christmas</option>
+                                                <option value="fuse_catalogue_easter">Easter</option>
+                                                <option value="fuse_catalogue_summer">Summer</option>
+                                                <option value="fuse_catalogue_halloween">Halloween</option>
+                                                <option value="fuse_catalogue_valentines">Valentines</option>
+                                            </select>
+                                        </td>
+                                        <td><input type="number" class="form-control form-control-sm cat-order" data-page-id="@catPage.Id" value="@catPage.OrderId" style="width:60px;" /></td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        <button class="btn btn-sm btn-success action-submit-btn mt-2" onclick="submitAction('CataloguePageVisibility')">Add Action</button>
+                    </div>
+
+                    <!-- Room CCTs Form -->
+                    <div id="form-RoomCcts" class="action-form" style="display:none;">
+                        <p class="text-muted">Theme public rooms for the campaign. Tick a room and fill any of the fields below — leave a field blank to keep its current value. CCTs, title and description are restored automatically when the campaign ends.</p>
+                        <table class="blueTable" id="room-ccts-table">
+                            <thead>
+                                <tr>
+                                    <th>Select</th>
+                                    <th>Current CCTs</th>
+                                    <th>New CCTs</th>
+                                    <th>Current Title</th>
+                                    <th>New Title</th>
+                                    <th>Current Description</th>
+                                    <th>New Description</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var room in Model.PublicRooms)
+                                {
+                                    <tr>
+                                        <td>
+                                            <input type="checkbox" class="room-cct-check" data-room-id="@room.Id" />
+                                        </td>
+                                        <td><code style="display:inline-block;max-width:220px;overflow-wrap:anywhere;">@room.Casts</code></td>
+                                        <td>
+                                            <input type="text" class="form-control form-control-sm room-cct-new"
+                                                   data-room-id="@room.Id" placeholder="e.g. @(room.Casts)_xmas" />
+                                        </td>
+                                        <td><code>@room.Name</code></td>
+                                        <td>
+                                            <input type="text" class="form-control form-control-sm room-name-new"
+                                                   data-room-id="@room.Id" placeholder="unchanged" />
+                                        </td>
+                                        <td><code>@room.Description</code></td>
+                                        <td>
+                                            <input type="text" class="form-control form-control-sm room-desc-new"
+                                                   data-room-id="@room.Id" placeholder="e.g. theatredrome_xmas" />
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        <button class="btn btn-sm btn-success action-submit-btn mt-2" onclick="submitAction('RoomCcts')">Add Action</button>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    <!-- Sidebar -->
+    <div class="col-md-4">
+        <!-- Activation Controls -->
+        <div class="card mb-3">
+            <div class="card-header">
+                <h4 class="text-uppercase">Controls</h4>
+            </div>
+            <div class="card-body">
+                @if (isDraft && campaign.Actions.Any())
+                {
+                    <form asp-action="Activate" method="post" class="mb-2">
+                        <input type="hidden" name="id" value="@campaign.Id" />
+                        <button type="submit" class="btn btn-success btn-block"
+                                onclick="return confirm('Activate this campaign? All actions will be applied.')">
+                            Activate Now
+                        </button>
+                    </form>
+                }
+                @if (isActive)
+                {
+                    <form asp-action="Deactivate" method="post" class="mb-2">
+                        <input type="hidden" name="id" value="@campaign.Id" />
+                        <button type="submit" class="btn btn-warning btn-block"
+                                onclick="return confirm('Deactivate this campaign? All changes will be reverted.')">
+                            Deactivate &amp; Revert
+                        </button>
+                    </form>
+                }
+                <hr />
+                <p class="text-muted small">
+                    <strong>Created:</strong> @campaign.CreatedAt.ToString("dd-MM-yyyy HH:mm")<br />
+                    @if (campaign.ActivatedAt.HasValue)
+                    {
+                        <strong>Activated:</strong> @campaign.ActivatedAt.Value.ToString("dd-MM-yyyy HH:mm")<br />
+                    }
+                    @if (campaign.ClonedFromId.HasValue)
+                    {
+                        <text><strong>Cloned from:</strong> Campaign #@(campaign.ClonedFromId)<br /></text>
+                    }
+                </p>
+            </div>
+        </div>
+
+        <!-- Info Card -->
+        <div class="card">
+            <div class="card-header">
+                <h4 class="text-uppercase">Help</h4>
+            </div>
+            <div class="card-body small">
+                <p><strong>How it works:</strong></p>
+                <ul>
+                    <li><strong>Draft</strong> - Configure actions, not yet active</li>
+                    <li><strong>Scheduled</strong> - Will auto-activate on start date</li>
+                    <li><strong>Active</strong> - Changes are live, cannot edit</li>
+                    <li><strong>Ended</strong> - Deactivated, changes reverted</li>
+                </ul>
+                <p>If multiple campaigns overlap on the same setting, the most recently activated one takes priority.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section scripts {
+    <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
+    <script>
+        $(document).ready(function () {
+            var datetimeSettings = { format: 'Y-m-d H:i:s' };
+            $("#startDatepicker").datetimepicker(datetimeSettings);
+            $("#endDatepicker").datetimepicker(datetimeSettings);
+
+            document.querySelectorAll('.edit-action-btn').forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    editAction(parseInt(this.dataset.actionId), this.dataset.actionType, this.dataset.actionData);
+                });
+            });
+        });
+
+        // Tracks the action currently being edited (null = adding a new action)
+        window.editingActionId = null;
+
+        function editAction(actionId, type, dataJson) {
+            window.editingActionId = actionId;
+
+            var data = {};
+            try { data = JSON.parse(dataJson); } catch (e) { }
+
+            var typeSelect = document.getElementById('actionTypeSelect');
+            typeSelect.value = type;
+            typeSelect.disabled = true; // type cannot change while editing
+            showActionForm();
+
+            populateActionForm(type, data);
+
+            document.getElementById('editModeBanner').style.display = 'block';
+            document.getElementById('actionCardTitle').textContent = 'Edit Action';
+            document.querySelectorAll('.action-submit-btn').forEach(function (b) { b.textContent = 'Save Changes'; });
+
+            var form = document.getElementById('form-' + type);
+            if (form) form.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+
+        function cancelEdit() {
+            window.editingActionId = null;
+            var typeSelect = document.getElementById('actionTypeSelect');
+            typeSelect.disabled = false;
+            typeSelect.value = '';
+            document.getElementById('editModeBanner').style.display = 'none';
+            document.getElementById('actionCardTitle').textContent = 'Add Action';
+            document.querySelectorAll('.action-submit-btn').forEach(function (b) { b.textContent = 'Add Action'; });
+            showActionForm();
+        }
+
+        function populateActionForm(type, data) {
+            switch (type) {
+                case 'ChangeBackground':
+                    document.getElementById('bg-value').value = data.value || '';
+                    break;
+                case 'ChangeBanner':
+                    document.getElementById('banner-value').value = data.value || '';
+                    break;
+                case 'CreateNews':
+                    document.getElementById('news-title').value = data.title || '';
+                    document.getElementById('news-slug').value = data.slug || '';
+                    document.getElementById('news-teaser').value = data.teaser || '';
+                    document.getElementById('news-writer').value = data.writer || '';
+                    document.getElementById('news-text').value = data.text || '';
+                    break;
+                case 'CataloguePageVisibility':
+                    document.querySelectorAll('.catalogue-page-check').forEach(function (cb) { cb.checked = false; });
+                    (data.pages || []).forEach(function (p) {
+                        var cb = document.querySelector('.catalogue-page-check[data-page-id="' + p.pageId + '"]');
+                        if (cb) cb.checked = true;
+                        var fuse = document.querySelector('.cat-fuse[data-page-id="' + p.pageId + '"]');
+                        if (fuse && p.fuse) fuse.value = p.fuse;
+                        var order = document.querySelector('.cat-order[data-page-id="' + p.pageId + '"]');
+                        if (order && p.orderId != null) order.value = p.orderId;
+                    });
+                    break;
+                case 'RoomCcts':
+                    document.querySelectorAll('.room-cct-check').forEach(function (cb) { cb.checked = false; });
+                    document.querySelectorAll('.room-cct-new').forEach(function (i) { i.value = ''; });
+                    document.querySelectorAll('.room-name-new').forEach(function (i) { i.value = ''; });
+                    document.querySelectorAll('.room-desc-new').forEach(function (i) { i.value = ''; });
+                    (data.rooms || []).forEach(function (r) {
+                        var cb = document.querySelector('.room-cct-check[data-room-id="' + r.roomId + '"]');
+                        if (cb) cb.checked = true;
+                        var ccts = document.querySelector('.room-cct-new[data-room-id="' + r.roomId + '"]');
+                        if (ccts) ccts.value = r.newCcts || '';
+                        var name = document.querySelector('.room-name-new[data-room-id="' + r.roomId + '"]');
+                        if (name) name.value = r.newName || '';
+                        var desc = document.querySelector('.room-desc-new[data-room-id="' + r.roomId + '"]');
+                        if (desc) desc.value = r.newDescription || '';
+                    });
+                    break;
+            }
+        }
+
+        function showActionForm() {
+            document.querySelectorAll('.action-form').forEach(f => f.style.display = 'none');
+            var type = document.getElementById('actionTypeSelect').value;
+            if (type) {
+                document.getElementById('form-' + type).style.display = 'block';
+            }
+        }
+
+        // Show/hide visibility select when catalogue page checkbox is toggled
+        // (no longer needed with table layout)
+
+        // Set initial selected values for catalogue fuse dropdowns
+        document.querySelectorAll('.cat-fuse').forEach(function (select) {
+            var current = select.dataset.current;
+            if (current) select.value = current;
+        });
+
+        function submitAction(type) {
+            var actionData = {};
+
+            switch (type) {
+                case 'ChangeBackground':
+                    actionData = { value: document.getElementById('bg-value').value };
+                    break;
+                case 'ChangeBanner':
+                    actionData = { value: document.getElementById('banner-value').value };
+                    break;
+                case 'CreateNews':
+                    actionData = {
+                        title: document.getElementById('news-title').value,
+                        slug: document.getElementById('news-slug').value,
+                        teaser: document.getElementById('news-teaser').value,
+                        writer: document.getElementById('news-writer').value,
+                        text: document.getElementById('news-text').value
+                    };
+                    break;
+                case 'CataloguePageVisibility':
+                    var pages = [];
+                    document.querySelectorAll('.catalogue-page-check:checked').forEach(function (cb) {
+                        var pageId = parseInt(cb.dataset.pageId);
+                        var fuse = document.querySelector('.cat-fuse[data-page-id="' + pageId + '"]').value;
+                        var orderId = parseInt(document.querySelector('.cat-order[data-page-id="' + pageId + '"]').value);
+                        pages.push({
+                            pageId: pageId,
+                            fuse: fuse,
+                            orderId: orderId,
+                            indexVisible: 1
+                        });
+                    });
+                    if (pages.length === 0) {
+                        alert('Please select at least one catalogue page');
+                        return;
+                    }
+                    actionData = { pages: pages };
+                    break;
+                case 'RoomCcts':
+                    var rooms = [];
+                    document.querySelectorAll('.room-cct-check:checked').forEach(function (cb) {
+                        var roomId = parseInt(cb.dataset.roomId);
+                        var newCcts = document.querySelector('.room-cct-new[data-room-id="' + roomId + '"]').value.trim();
+                        var newName = document.querySelector('.room-name-new[data-room-id="' + roomId + '"]').value.trim();
+                        var newDesc = document.querySelector('.room-desc-new[data-room-id="' + roomId + '"]').value.trim();
+                        if (newCcts || newName || newDesc) {
+                            var entry = { roomId: roomId };
+                            if (newCcts) entry.newCcts = newCcts;
+                            if (newName) entry.newName = newName;
+                            if (newDesc) entry.newDescription = newDesc;
+                            rooms.push(entry);
+                        }
+                    });
+                    if (rooms.length === 0) {
+                        alert('Please select at least one room and provide a new CCT, title, or description value');
+                        return;
+                    }
+                    actionData = { rooms: rooms };
+                    break;
+            }
+
+            // Submit via form
+            var editing = window.editingActionId;
+            var form = document.createElement('form');
+            form.method = 'POST';
+            form.action = editing ? '@Url.Action("UpdateAction")' : '@Url.Action("AddAction")';
+
+            var campaignIdInput = document.createElement('input');
+            campaignIdInput.type = 'hidden';
+            campaignIdInput.name = 'CampaignId';
+            campaignIdInput.value = '@campaign.Id';
+            form.appendChild(campaignIdInput);
+
+            if (editing) {
+                var actionIdInput = document.createElement('input');
+                actionIdInput.type = 'hidden';
+                actionIdInput.name = 'ActionId';
+                actionIdInput.value = editing;
+                form.appendChild(actionIdInput);
+            } else {
+                var typeInput = document.createElement('input');
+                typeInput.type = 'hidden';
+                typeInput.name = 'ActionType';
+                typeInput.value = type;
+                form.appendChild(typeInput);
+            }
+
+            var dataInput = document.createElement('input');
+            dataInput.type = 'hidden';
+            dataInput.name = 'ActionData';
+            dataInput.value = JSON.stringify(actionData);
+            form.appendChild(dataInput);
+
+            document.body.appendChild(form);
+            form.submit();
+        }
+    </script>
+}
+
+@functions {
+    string GetActionSummary(KeplerCMS.Data.Models.CampaignAction action)
+    {
+        try
+        {
+            switch (action.ActionType)
+            {
+                case "ChangeBackground":
+                    var bgData = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(action.ActionData);
+                    return $"Set background to: {bgData.GetValueOrDefault("value", "?")}";
+                case "ChangeBanner":
+                    var bannerData = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(action.ActionData);
+                    return $"Set banner to: {bannerData.GetValueOrDefault("value", "?")}";
+                case "CreateNews":
+                    var newsData = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(action.ActionData);
+                    return $"Create article: \"{newsData.GetValueOrDefault("title", "?")}\"";
+                case "CataloguePageVisibility":
+                    var catData = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(action.ActionData);
+                    var catPageCount = catData.GetProperty("pages").GetArrayLength();
+                    return $"Update {catPageCount} catalogue page(s) (fuse/order)";
+                case "RoomCcts":
+                    var roomData = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(action.ActionData);
+                    var roomCount = roomData.GetProperty("rooms").GetArrayLength();
+                    return $"Update CCTs for {roomCount} room(s)";
+                default:
+                    return action.ActionType;
+            }
+        }
+        catch
+        {
+            return action.ActionType;
+        }
+    }
+}

--- a/Areas/Housekeeping/Views/Campaigns/Index.cshtml
+++ b/Areas/Housekeeping/Views/Campaigns/Index.cshtml
@@ -1,0 +1,134 @@
+@model KeplerCMS.Areas.Housekeeping.Models.Views.CampaignListViewModel
+
+<h1>Campaigns</h1>
+
+@if (!string.IsNullOrEmpty(Model.Message))
+{
+    <div class="message">
+        @Model.Message
+    </div>
+}
+
+<div class="mb-3">
+    <a href="@Url.Action("Create")" class="btn btn-sm btn-primary">Create Campaign</a>
+</div>
+
+<table class="blueTable">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Start Date</th>
+            <th>End Date</th>
+            <th>Actions</th>
+            <th>Created</th>
+            <th>Operations</th>
+        </tr>
+    </thead>
+    <tbody>
+        @if (Model.Campaigns != null && Model.Campaigns.Any())
+        {
+            foreach (var campaign in Model.Campaigns)
+            {
+                var statusClass = campaign.Status switch
+                {
+                    "active" => "badge-success",
+                    "scheduled" => "badge-info",
+                    "ended" => "badge-secondary",
+                    "cancelled" => "badge-danger",
+                    _ => "badge-warning"
+                };
+                <tr>
+                    <td>@campaign.Name</td>
+                    <td><span class="badge @statusClass">@campaign.Status</span></td>
+                    <td>@(campaign.StartDate?.ToString("dd-MM-yyyy HH:mm") ?? "Manual")</td>
+                    <td>@(campaign.EndDate?.ToString("dd-MM-yyyy HH:mm") ?? "Manual")</td>
+                    <td>@campaign.Actions.Count action(s)</td>
+                    <td>@campaign.CreatedAt.ToString("dd-MM-yyyy")</td>
+                    <td>
+                        <a href="@Url.Action("Edit", new { id = campaign.Id })">Edit</a>
+                        @if (campaign.Status != "active")
+                        {
+                            <span> - </span>
+                            <a href="#" onclick="cloneCampaign(@campaign.Id, '@campaign.Name')">Clone</a>
+                            <span> - </span>
+                            <a href="#" onclick="deleteCampaign(@campaign.Id)">Delete</a>
+                        }
+                    </td>
+                </tr>
+            }
+        }
+        else
+        {
+            <tr>
+                <td colspan="7">No campaigns created yet</td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+@section scripts {
+    <script>
+        function cloneCampaign(id, name) {
+            Swal.fire({
+                title: 'Clone Campaign',
+                text: 'Enter a name for the cloned campaign:',
+                input: 'text',
+                inputValue: name + ' (Copy)',
+                showCancelButton: true,
+                confirmButtonText: 'Clone',
+                inputValidator: (value) => {
+                    if (!value) return 'Please enter a name';
+                }
+            }).then((result) => {
+                if (result.value) {
+                    var form = document.createElement('form');
+                    form.method = 'POST';
+                    form.action = '@Url.Action("Clone")';
+
+                    var idInput = document.createElement('input');
+                    idInput.type = 'hidden';
+                    idInput.name = 'CampaignId';
+                    idInput.value = id;
+                    form.appendChild(idInput);
+
+                    var nameInput = document.createElement('input');
+                    nameInput.type = 'hidden';
+                    nameInput.name = 'NewName';
+                    nameInput.value = result.value;
+                    form.appendChild(nameInput);
+
+                    document.body.appendChild(form);
+                    form.submit();
+                }
+            });
+        }
+
+        function deleteCampaign(id) {
+            Swal.fire({
+                title: 'Are you sure?',
+                text: "This will permanently delete the campaign!",
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#3085d6',
+                cancelButtonColor: '#d33',
+                confirmButtonText: 'Yes, delete it!'
+            }).then((result) => {
+                if (result.value) {
+                    var form = document.createElement('form');
+                    form.method = 'POST';
+                    form.action = '@Url.Action("Delete")';
+
+                    var idInput = document.createElement('input');
+                    idInput.type = 'hidden';
+                    idInput.name = 'id';
+                    idInput.value = id;
+                    form.appendChild(idInput);
+
+                    document.body.appendChild(form);
+                    form.submit();
+                }
+            });
+        }
+    </script>
+}

--- a/Areas/Housekeeping/Views/Menu/Create.cshtml
+++ b/Areas/Housekeeping/Views/Menu/Create.cshtml
@@ -44,10 +44,32 @@
                 </select>
                 <span asp-validation-for="State" class="text-danger"></span>
             </div>
+            <div class="form-group">
+                <label class="label-control">Schedule start (optional)</label>
+                <input type="text" id="startDatepicker" name="StartDate" value="@(Model?.StartDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no start" autocomplete="off" />
+                <small class="text-muted">When set, the item only shows from this time.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule end (optional)</label>
+                <input type="text" id="endDatepicker" name="EndDate" value="@(Model?.EndDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no end" autocomplete="off" />
+                <small class="text-muted">When set, the item stops showing after this time.</small>
+            </div>
 
             <div class="form-group">
                 <button type="submit" class="btn btn-sm btn-primary">Submit</button>
             </div>
         </form>
     </div>
-</div>  
+</div>
+
+@section scripts {
+    <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
+    <script>
+        $(document).ready(function () {
+            var datetimeSettings = { format: 'Y-m-d H:i:s' };
+            $("#startDatepicker").datetimepicker(datetimeSettings);
+            $("#endDatepicker").datetimepicker(datetimeSettings);
+        });
+    </script>
+}

--- a/Areas/Housekeeping/Views/Menu/Update.cshtml
+++ b/Areas/Housekeeping/Views/Menu/Update.cshtml
@@ -45,10 +45,32 @@
                 </select>
                 <span asp-validation-for="State" class="text-danger"></span>
             </div>
+            <div class="form-group">
+                <label class="label-control">Schedule start (optional)</label>
+                <input type="text" id="startDatepicker" name="StartDate" value="@(Model.StartDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no start" autocomplete="off" />
+                <small class="text-muted">When set, the item only shows from this time.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule end (optional)</label>
+                <input type="text" id="endDatepicker" name="EndDate" value="@(Model.EndDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no end" autocomplete="off" />
+                <small class="text-muted">When set, the item stops showing after this time.</small>
+            </div>
 
             <div class="form-group">
                 <button type="submit" class="btn btn-sm btn-primary">Submit</button>
             </div>
         </form>
     </div>
-</div>  
+</div>
+
+@section scripts {
+    <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
+    <script>
+        $(document).ready(function () {
+            var datetimeSettings = { format: 'Y-m-d H:i:s' };
+            $("#startDatepicker").datetimepicker(datetimeSettings);
+            $("#endDatepicker").datetimepicker(datetimeSettings);
+        });
+    </script>
+}

--- a/Areas/Housekeeping/Views/Pages/CreateContainer.cshtml
+++ b/Areas/Housekeeping/Views/Pages/CreateContainer.cshtml
@@ -69,6 +69,17 @@
                 <label asp-for="Hidden" class="label-control"></label>
                 <input asp-for="Hidden" class="form-control" />
                 <span asp-validation-for="Hidden" class="text-danger"></span>
+                <small class="text-muted d-block">If checked, the container is always hidden regardless of the schedule below.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule start (optional)</label>
+                <input type="text" id="startDatepicker" name="StartDate" value="@(Model.StartDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no start" autocomplete="off" />
+                <small class="text-muted">When set, the container only shows from this time.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule end (optional)</label>
+                <input type="text" id="endDatepicker" name="EndDate" value="@(Model.EndDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no end" autocomplete="off" />
+                <small class="text-muted">When set, the container stops showing after this time.</small>
             </div>
 
             <div class="form-group">
@@ -79,10 +90,15 @@
 </div>
 
 @section scripts {
+    <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
     <script src="~/housekeeping/js/tinymce/tinymce.min.js"></script>
     <script src="~/housekeeping/js/tinymce/jquery.tinymce.min.js"></script>
     <script>
         $(document).ready(function () {
+            var datetimeSettings = { format: 'Y-m-d H:i:s' };
+            $("#startDatepicker").datetimepicker(datetimeSettings);
+            $("#endDatepicker").datetimepicker(datetimeSettings);
             $('#editor').tinymce({
                 relative_urls: false,
                 convert_urls: false,

--- a/Areas/Housekeeping/Views/Pages/UpdateContainer.cshtml
+++ b/Areas/Housekeeping/Views/Pages/UpdateContainer.cshtml
@@ -68,6 +68,17 @@
                 <label asp-for="Hidden" class="label-control"></label>
                 <input asp-for="Hidden" class="form-control" />
                 <span asp-validation-for="Hidden" class="text-danger"></span>
+                <small class="text-muted d-block">If checked, the container is always hidden regardless of the schedule below.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule start (optional)</label>
+                <input type="text" id="startDatepicker" name="StartDate" value="@(Model.StartDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no start" autocomplete="off" />
+                <small class="text-muted">When set, the container only shows from this time.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule end (optional)</label>
+                <input type="text" id="endDatepicker" name="EndDate" value="@(Model.EndDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no end" autocomplete="off" />
+                <small class="text-muted">When set, the container stops showing after this time.</small>
             </div>
 
             <div class="form-group">
@@ -78,10 +89,15 @@
 </div>
 
 @section scripts {
+    <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
     <script src="~/housekeeping/js/tinymce/tinymce.min.js"></script>
     <script src="~/housekeeping/js/tinymce/jquery.tinymce.min.js"></script>
     <script>
         $(document).ready(function () {
+            var datetimeSettings = { format: 'Y-m-d H:i:s' };
+            $("#startDatepicker").datetimepicker(datetimeSettings);
+            $("#endDatepicker").datetimepicker(datetimeSettings);
             $('#editor').tinymce({
                 relative_urls: false,
                 convert_urls: false,

--- a/Areas/Housekeeping/Views/Promo/Create.cshtml
+++ b/Areas/Housekeeping/Views/Promo/Create.cshtml
@@ -41,6 +41,17 @@
                 <label asp-for="Hidden" class="label-control"></label>
                 <input asp-for="Hidden" class="form-control" />
                 <span asp-validation-for="Hidden" class="text-danger"></span>
+                <small class="text-muted d-block">If checked, the promo is always hidden regardless of the schedule below.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule start (optional)</label>
+                <input type="text" id="startDatepicker" name="StartDate" value="@(Model?.StartDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no start" autocomplete="off" />
+                <small class="text-muted">When set, the promo only shows from this time.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule end (optional)</label>
+                <input type="text" id="endDatepicker" name="EndDate" value="@(Model?.EndDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no end" autocomplete="off" />
+                <small class="text-muted">When set, the promo stops showing after this time.</small>
             </div>
 
             <div class="form-group">
@@ -48,4 +59,16 @@
             </div>
         </form>
     </div>
-</div>  
+</div>
+
+@section scripts {
+    <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
+    <script>
+        $(document).ready(function () {
+            var datetimeSettings = { format: 'Y-m-d H:i:s' };
+            $("#startDatepicker").datetimepicker(datetimeSettings);
+            $("#endDatepicker").datetimepicker(datetimeSettings);
+        });
+    </script>
+}

--- a/Areas/Housekeeping/Views/Promo/Update.cshtml
+++ b/Areas/Housekeeping/Views/Promo/Update.cshtml
@@ -42,6 +42,17 @@
                 <label asp-for="Hidden" class="label-control"></label>
                 <input asp-for="Hidden" class="form-control" />
                 <span asp-validation-for="Hidden" class="text-danger"></span>
+                <small class="text-muted d-block">If checked, the promo is always hidden regardless of the schedule below.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule start (optional)</label>
+                <input type="text" id="startDatepicker" name="StartDate" value="@(Model.StartDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no start" autocomplete="off" />
+                <small class="text-muted">When set, the promo only shows from this time.</small>
+            </div>
+            <div class="form-group">
+                <label class="label-control">Schedule end (optional)</label>
+                <input type="text" id="endDatepicker" name="EndDate" value="@(Model.EndDate?.ToString("yyyy-MM-dd HH:mm:ss"))" class="form-control" placeholder="Leave blank for no end" autocomplete="off" />
+                <small class="text-muted">When set, the promo stops showing after this time.</small>
             </div>
 
             <div class="form-group">
@@ -49,4 +60,16 @@
             </div>
         </form>
     </div>
-</div>  
+</div>
+
+@section scripts {
+    <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
+    <script>
+        $(document).ready(function () {
+            var datetimeSettings = { format: 'Y-m-d H:i:s' };
+            $("#startDatepicker").datetimepicker(datetimeSettings);
+            $("#endDatepicker").datetimepicker(datetimeSettings);
+        });
+    </script>
+}

--- a/Areas/Housekeeping/Views/Shared/_Housekeeping.cshtml
+++ b/Areas/Housekeeping/Views/Shared/_Housekeeping.cshtml
@@ -33,6 +33,7 @@
         { "/housekeeping/bots", HousekeepingMenu.AdminTools },
         { "/housekeeping/rewards", HousekeepingMenu.AdminTools },
         { "/housekeeping/polls", HousekeepingMenu.AdminTools },
+        { "/housekeeping/campaigns", HousekeepingMenu.AdminTools },
         { "/housekeeping/callsforhelp", HousekeepingMenu.HobbaTools },
     };
 
@@ -120,6 +121,7 @@
                                 @await menuHelper.Render("Audit log", Url.Action("Index", "AuditLog"), new List<Fuse> { Fuse.fuse_administrator_access })
                                 @await menuHelper.Render("Reward management", Url.Action("Index", "Rewards"), new List<Fuse> { Fuse.housekeeping_rewards })
                                 @await menuHelper.Render("Catalogue", Url.Action("Index", "Catalogue"), new List<Fuse> { Fuse.fuse_administrator_access })
+                                @await menuHelper.Render("Campaigns", Url.Action("Index", "Campaigns"), new List<Fuse> { Fuse.fuse_campaigns })
                                 @await menuHelper.Render("Bots", Url.Action("Index", "Bots"), new List<Fuse> { Fuse.fuse_bots })
                                 @await menuHelper.Render("Polls / Surveys", Url.Action("Index", "Polls"), new List<Fuse> { Fuse.fuse_administrator_access })
                             </ul>

--- a/BackgroundServices/CampaignSchedulerService.cs
+++ b/BackgroundServices/CampaignSchedulerService.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using KeplerCMS.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace KeplerCMS.BackgroundServices
+{
+    public class CampaignSchedulerService : BackgroundService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<CampaignSchedulerService> _logger;
+        private readonly TimeSpan _checkInterval = TimeSpan.FromSeconds(60);
+
+        public CampaignSchedulerService(
+            IServiceProvider serviceProvider,
+            ILogger<CampaignSchedulerService> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("Campaign Scheduler Service started");
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await CheckCampaigns();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error checking campaign schedules");
+                }
+
+                await Task.Delay(_checkInterval, stoppingToken);
+            }
+
+            _logger.LogInformation("Campaign Scheduler Service stopped");
+        }
+
+        private async Task CheckCampaigns()
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var campaignService = scope.ServiceProvider.GetRequiredService<ICampaignService>();
+            var campaignExecutor = scope.ServiceProvider.GetRequiredService<ICampaignExecutor>();
+
+            // Activate scheduled campaigns whose start date has passed
+            var toActivate = await campaignService.GetScheduledCampaignsToActivate();
+            foreach (var campaign in toActivate)
+            {
+                _logger.LogInformation("Auto-activating scheduled campaign {CampaignId} ({Name})", campaign.Id, campaign.Name);
+                await campaignExecutor.ActivateCampaign(campaign.Id);
+            }
+
+            // Deactivate active campaigns whose end date has passed
+            var toEnd = await campaignService.GetActiveCampaignsToEnd();
+            foreach (var campaign in toEnd)
+            {
+                _logger.LogInformation("Auto-deactivating expired campaign {CampaignId} ({Name})", campaign.Id, campaign.Name);
+                await campaignExecutor.DeactivateCampaign(campaign.Id);
+            }
+        }
+    }
+}

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -116,6 +116,9 @@ namespace KeplerCMS.Data
         public DbSet<UsersBans> UsersBans { get; set; }
         public DbSet<AuditLog> AuditLogs { get; set; }
         public DbSet<CallsForHelp> CallsForHelp { get; set; }
+        public DbSet<Campaign> Campaigns { get; set; }
+        public DbSet<CampaignAction> CampaignActions { get; set; }
+        public DbSet<CampaignSnapshot> CampaignSnapshots { get; set; }
         public DataContext(DbContextOptions<DataContext> options)
             : base(options) { }
     }

--- a/Data/Models/Campaign.cs
+++ b/Data/Models/Campaign.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using KeplerCMS.Models.Enums;
+
+namespace KeplerCMS.Data.Models
+{
+    [Table("cms_campaigns")]
+    public class Campaign
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("name")]
+        [Required]
+        public string Name { get; set; }
+
+        [Column("description")]
+        public string Description { get; set; }
+
+        [Column("start_date")]
+        public DateTime? StartDate { get; set; }
+
+        [Column("end_date")]
+        public DateTime? EndDate { get; set; }
+
+        [Column("status")]
+        public string Status { get; set; }
+
+        [Column("activated_at")]
+        public DateTime? ActivatedAt { get; set; }
+
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [Column("created_by_id")]
+        public int CreatedById { get; set; }
+
+        [Column("cloned_from_id")]
+        public int? ClonedFromId { get; set; }
+
+        [NotMapped]
+        public CampaignStatus StatusEnum
+        {
+            get => Enum.TryParse<CampaignStatus>(Status, true, out var result) ? result : CampaignStatus.Draft;
+            set => Status = value.ToString().ToLower();
+        }
+
+        [ForeignKey("CreatedById")]
+        public Users CreatedBy { get; set; }
+
+        [ForeignKey("ClonedFromId")]
+        public Campaign ClonedFrom { get; set; }
+
+        public List<CampaignAction> Actions { get; set; } = new List<CampaignAction>();
+        public List<CampaignSnapshot> Snapshots { get; set; } = new List<CampaignSnapshot>();
+    }
+}

--- a/Data/Models/CampaignAction.cs
+++ b/Data/Models/CampaignAction.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace KeplerCMS.Data.Models
+{
+    [Table("cms_campaign_actions")]
+    public class CampaignAction
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("campaign_id")]
+        public int CampaignId { get; set; }
+
+        [Column("action_type")]
+        [Required]
+        public string ActionType { get; set; }
+
+        [Column("action_data")]
+        [Required]
+        public string ActionData { get; set; }
+
+        [Column("order_index")]
+        public int OrderIndex { get; set; }
+
+        [ForeignKey("CampaignId")]
+        public Campaign Campaign { get; set; }
+    }
+}

--- a/Data/Models/CampaignSnapshot.cs
+++ b/Data/Models/CampaignSnapshot.cs
@@ -1,0 +1,36 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace KeplerCMS.Data.Models
+{
+    [Table("cms_campaign_snapshots")]
+    public class CampaignSnapshot
+    {
+        [Column("id")]
+        public int Id { get; set; }
+
+        [Column("campaign_id")]
+        public int CampaignId { get; set; }
+
+        [Column("action_id")]
+        public int ActionId { get; set; }
+
+        [Column("conflict_key")]
+        [Required]
+        public string ConflictKey { get; set; }
+
+        [Column("original_data")]
+        [Required]
+        public string OriginalData { get; set; }
+
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [ForeignKey("CampaignId")]
+        public Campaign Campaign { get; set; }
+
+        [ForeignKey("ActionId")]
+        public CampaignAction Action { get; set; }
+    }
+}

--- a/Data/Models/Containers.cs
+++ b/Data/Models/Containers.cs
@@ -27,12 +27,31 @@ namespace KeplerCMS.Data.Models
         public int Order { get; set; }
         [Column("hidden")]
         public int IHidden { get; set; }
-        
+
+        [Column("start_date")]
+        public DateTime? StartDate { get; set; }
+
+        [Column("end_date")]
+        public DateTime? EndDate { get; set; }
+
         [NotMapped]
         public bool Hidden
         {
             get => IHidden == 1;
             set => IHidden = value ? 1 : 0;
+        }
+
+        // True when the container is within its (optional) scheduled window right now.
+        // An empty bound is open-ended. Bounds are inclusive.
+        [NotMapped]
+        public bool IsScheduledVisible
+        {
+            get
+            {
+                var now = DateTime.Now;
+                return (StartDate == null || StartDate <= now)
+                    && (EndDate == null || EndDate >= now);
+            }
         }
 
         [NotMapped]

--- a/Data/Models/Menu.cs
+++ b/Data/Models/Menu.cs
@@ -25,5 +25,22 @@ namespace KeplerCMS.Data.Models
         public int Order { get; set; }
         [Column("state")]
         public string State { get; set; }
+        [Column("start_date")]
+        public DateTime? StartDate { get; set; }
+        [Column("end_date")]
+        public DateTime? EndDate { get; set; }
+
+        // True when the menu item is within its (optional) scheduled window right now.
+        // An empty bound is open-ended. Bounds are inclusive.
+        [NotMapped]
+        public bool IsScheduledVisible
+        {
+            get
+            {
+                var now = DateTime.Now;
+                return (StartDate == null || StartDate <= now)
+                    && (EndDate == null || EndDate >= now);
+            }
+        }
     }
 }

--- a/Data/Models/Promo.cs
+++ b/Data/Models/Promo.cs
@@ -37,6 +37,23 @@ namespace KeplerCMS.Data.Models
         [Column("order")]
         public int Order { get; set; }
 
+        [Column("start_date")]
+        public DateTime? StartDate { get; set; }
 
+        [Column("end_date")]
+        public DateTime? EndDate { get; set; }
+
+        // True when the promo is within its (optional) scheduled window right now.
+        // An empty bound is open-ended. Bounds are inclusive.
+        [NotMapped]
+        public bool IsScheduledVisible
+        {
+            get
+            {
+                var now = DateTime.Now;
+                return (StartDate == null || StartDate <= now)
+                    && (EndDate == null || EndDate >= now);
+            }
+        }
     }
 }

--- a/Models/Enums/CampaignActionType.cs
+++ b/Models/Enums/CampaignActionType.cs
@@ -1,0 +1,11 @@
+namespace KeplerCMS.Models.Enums
+{
+    public enum CampaignActionType
+    {
+        ChangeBackground,
+        ChangeBanner,
+        CreateNews,
+        CataloguePageVisibility,
+        RoomCcts
+    }
+}

--- a/Models/Enums/CampaignStatus.cs
+++ b/Models/Enums/CampaignStatus.cs
@@ -1,0 +1,11 @@
+namespace KeplerCMS.Models.Enums
+{
+    public enum CampaignStatus
+    {
+        Draft,
+        Scheduled,
+        Active,
+        Ended,
+        Cancelled
+    }
+}

--- a/Models/Enums/CommandQueueType.cs
+++ b/Models/Enums/CommandQueueType.cs
@@ -19,6 +19,8 @@ namespace KeplerCMS.Models.Enums
         remote_kick,
         update_room,
         update_infobus,
-        reset_bots
+        reset_bots,
+        reload_catalogue,
+        reload_navigator
     }
 }

--- a/Models/Enums/Fuse.cs
+++ b/Models/Enums/Fuse.cs
@@ -48,7 +48,9 @@ namespace KeplerCMS.Models
         [Description("fuse_bots")]
         fuse_bots,
         [Description("fuse_receive_calls_for_help")]
-        fuse_receive_calls_for_help
+        fuse_receive_calls_for_help,
+        [Description("fuse_campaigns")]
+        fuse_campaigns
         
     }
 }

--- a/Services/CampaignActions/BackgroundActionHandler.cs
+++ b/Services/CampaignActions/BackgroundActionHandler.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Services.Interfaces;
+
+namespace KeplerCMS.Services.CampaignActions
+{
+    public class BackgroundActionHandler : ICampaignActionHandler
+    {
+        private readonly ISettingsService _settingsService;
+        private const string SettingKey = "cms.background";
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public BackgroundActionHandler(ISettingsService settingsService)
+        {
+            _settingsService = settingsService;
+        }
+
+        public async Task<string> TakeSnapshot(string actionData)
+        {
+            var currentSetting = await _settingsService.Get(SettingKey, "0");
+            return JsonSerializer.Serialize(new BackgroundActionData { Value = currentSetting.Value });
+        }
+
+        public async Task Apply(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<BackgroundActionData>(actionData, _jsonOptions);
+            var setting = new Data.Models.Settings { Setting = SettingKey, Value = data.Value ?? "0" };
+            await _settingsService.Update(setting);
+        }
+
+        public async Task Revert(string snapshotData)
+        {
+            var data = JsonSerializer.Deserialize<BackgroundActionData>(snapshotData, _jsonOptions);
+            var setting = new Data.Models.Settings { Setting = SettingKey, Value = data.Value ?? "0" };
+            await _settingsService.Update(setting);
+        }
+
+        public string GetConflictKey(string actionData)
+        {
+            return "setting:cms.background";
+        }
+    }
+
+    public class BackgroundActionData
+    {
+        public string Value { get; set; }
+    }
+}

--- a/Services/CampaignActions/BannerActionHandler.cs
+++ b/Services/CampaignActions/BannerActionHandler.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Services.Interfaces;
+
+namespace KeplerCMS.Services.CampaignActions
+{
+    public class BannerActionHandler : ICampaignActionHandler
+    {
+        private readonly ISettingsService _settingsService;
+        private const string SettingKey = "cms.hotel_banner";
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public BannerActionHandler(ISettingsService settingsService)
+        {
+            _settingsService = settingsService;
+        }
+
+        public async Task<string> TakeSnapshot(string actionData)
+        {
+            var currentSetting = await _settingsService.Get(SettingKey, "0");
+            return JsonSerializer.Serialize(new BannerActionData { Value = currentSetting.Value });
+        }
+
+        public async Task Apply(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<BannerActionData>(actionData, _jsonOptions);
+            var setting = new Data.Models.Settings { Setting = SettingKey, Value = data.Value ?? "0" };
+            await _settingsService.Update(setting);
+        }
+
+        public async Task Revert(string snapshotData)
+        {
+            var data = JsonSerializer.Deserialize<BannerActionData>(snapshotData, _jsonOptions);
+            var setting = new Data.Models.Settings { Setting = SettingKey, Value = data.Value ?? "0" };
+            await _settingsService.Update(setting);
+        }
+
+        public string GetConflictKey(string actionData)
+        {
+            return "setting:cms.hotel_banner";
+        }
+    }
+
+    public class BannerActionData
+    {
+        public string Value { get; set; }
+    }
+}

--- a/Services/CampaignActions/CampaignActionHandlerFactory.cs
+++ b/Services/CampaignActions/CampaignActionHandlerFactory.cs
@@ -1,0 +1,39 @@
+using System;
+using KeplerCMS.Models.Enums;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KeplerCMS.Services.CampaignActions
+{
+    public interface ICampaignActionHandlerFactory
+    {
+        ICampaignActionHandler GetHandler(string actionType);
+    }
+
+    public class CampaignActionHandlerFactory : ICampaignActionHandlerFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public CampaignActionHandlerFactory(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public ICampaignActionHandler GetHandler(string actionType)
+        {
+            if (!Enum.TryParse<CampaignActionType>(actionType, true, out var type))
+            {
+                throw new ArgumentException($"Unknown campaign action type: {actionType}");
+            }
+
+            return type switch
+            {
+                CampaignActionType.ChangeBackground => _serviceProvider.GetRequiredService<BackgroundActionHandler>(),
+                CampaignActionType.ChangeBanner => _serviceProvider.GetRequiredService<BannerActionHandler>(),
+                CampaignActionType.CreateNews => _serviceProvider.GetRequiredService<NewsActionHandler>(),
+                CampaignActionType.CataloguePageVisibility => _serviceProvider.GetRequiredService<CatalogueVisibilityActionHandler>(),
+                CampaignActionType.RoomCcts => _serviceProvider.GetRequiredService<RoomCctsActionHandler>(),
+                _ => throw new ArgumentException($"No handler registered for action type: {actionType}")
+            };
+        }
+    }
+}

--- a/Services/CampaignActions/CatalogueVisibilityActionHandler.cs
+++ b/Services/CampaignActions/CatalogueVisibilityActionHandler.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace KeplerCMS.Services.CampaignActions
+{
+    public class CatalogueVisibilityActionHandler : ICampaignActionHandler
+    {
+        private readonly DataContext _context;
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public CatalogueVisibilityActionHandler(DataContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<string> TakeSnapshot(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<CatalogueVisibilityActionData>(actionData, _jsonOptions);
+            var pageIds = data.Pages.Select(p => p.PageId).ToList();
+            
+            var currentStates = await _context.CataloguePages
+                .Where(p => pageIds.Contains(p.Id))
+                .Select(p => new CataloguePageSnapshot
+                {
+                    PageId = p.Id,
+                    IndexVisible = p.IndexVisible,
+                    ClubOnly = p.ClubOnly,
+                    Fuse = p.Fuse,
+                    OrderId = p.OrderId
+                })
+                .ToListAsync();
+
+            return JsonSerializer.Serialize(new CatalogueVisibilitySnapshotData { Pages = currentStates });
+        }
+
+        public async Task Apply(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<CatalogueVisibilityActionData>(actionData, _jsonOptions);
+            
+            foreach (var pageChange in data.Pages)
+            {
+                var page = await _context.CataloguePages.FindAsync(pageChange.PageId);
+                if (page != null)
+                {
+                    if (pageChange.IndexVisible.HasValue)
+                        page.IndexVisible = pageChange.IndexVisible.Value;
+                    if (pageChange.ClubOnly.HasValue)
+                        page.ClubOnly = pageChange.ClubOnly.Value;
+                    if (pageChange.Fuse != null)
+                        page.Fuse = pageChange.Fuse;
+                    if (pageChange.OrderId.HasValue)
+                        page.OrderId = pageChange.OrderId.Value;
+                }
+            }
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task Revert(string snapshotData)
+        {
+            var data = JsonSerializer.Deserialize<CatalogueVisibilitySnapshotData>(snapshotData, _jsonOptions);
+
+            foreach (var pageState in data.Pages)
+            {
+                var page = await _context.CataloguePages.FindAsync(pageState.PageId);
+                if (page != null)
+                {
+                    page.IndexVisible = pageState.IndexVisible;
+                    page.ClubOnly = pageState.ClubOnly;
+                    page.Fuse = pageState.Fuse;
+                    page.OrderId = pageState.OrderId;
+                }
+            }
+
+            await _context.SaveChangesAsync();
+        }
+
+        public string GetConflictKey(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<CatalogueVisibilityActionData>(actionData, _jsonOptions);
+            var pageIds = string.Join(",", data.Pages.Select(p => p.PageId).OrderBy(id => id));
+            return $"catalogue_visibility:{pageIds}";
+        }
+    }
+
+    public class CatalogueVisibilityActionData
+    {
+        public List<CataloguePageChange> Pages { get; set; } = new List<CataloguePageChange>();
+    }
+
+    /// <summary>
+    /// Defines desired state for a catalogue page when campaign is active.
+    /// Null values mean "don't change this field".
+    /// </summary>
+    public class CataloguePageChange
+    {
+        public int PageId { get; set; }
+        public int? IndexVisible { get; set; }
+        public int? ClubOnly { get; set; }
+        public string Fuse { get; set; }
+        public int? OrderId { get; set; }
+    }
+
+    public class CatalogueVisibilitySnapshotData
+    {
+        public List<CataloguePageSnapshot> Pages { get; set; } = new List<CataloguePageSnapshot>();
+    }
+
+    /// <summary>
+    /// Stores the original state of a catalogue page before campaign modification.
+    /// </summary>
+    public class CataloguePageSnapshot
+    {
+        public int PageId { get; set; }
+        public int IndexVisible { get; set; }
+        public int ClubOnly { get; set; }
+        public string Fuse { get; set; }
+        public int OrderId { get; set; }
+    }
+}

--- a/Services/CampaignActions/ICampaignActionHandler.cs
+++ b/Services/CampaignActions/ICampaignActionHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+
+namespace KeplerCMS.Services.CampaignActions
+{
+    public interface ICampaignActionHandler
+    {
+        /// <summary>
+        /// Takes a snapshot of the current state for the given action data.
+        /// Returns JSON representing the current state that can be restored later.
+        /// </summary>
+        Task<string> TakeSnapshot(string actionData);
+
+        /// <summary>
+        /// Applies the campaign action (makes the change).
+        /// </summary>
+        Task Apply(string actionData);
+
+        /// <summary>
+        /// Reverts the campaign action using the stored snapshot data.
+        /// </summary>
+        Task Revert(string snapshotData);
+
+        /// <summary>
+        /// Returns a unique key identifying what setting/resource this action targets.
+        /// Used for conflict detection between overlapping campaigns.
+        /// </summary>
+        string GetConflictKey(string actionData);
+    }
+}

--- a/Services/CampaignActions/NewsActionHandler.cs
+++ b/Services/CampaignActions/NewsActionHandler.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Data.Models;
+using KeplerCMS.Services.Interfaces;
+
+namespace KeplerCMS.Services.CampaignActions
+{
+    public class NewsActionHandler : ICampaignActionHandler
+    {
+        private readonly INewsService _newsService;
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public NewsActionHandler(INewsService newsService)
+        {
+            _newsService = newsService;
+        }
+
+        public Task<string> TakeSnapshot(string actionData)
+        {
+            // News creation doesn't have a "previous state" - we store the created article ID
+            // so we can delete it on revert. Initially empty until after Apply.
+            return Task.FromResult(JsonSerializer.Serialize(new NewsSnapshotData { CreatedNewsId = null }));
+        }
+
+        public async Task Apply(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<NewsActionData>(actionData, _jsonOptions);
+            var news = new News
+            {
+                Title = data.Title,
+                Slug = data.Slug ?? GenerateSlug(data.Title),
+                Teaser = data.Teaser,
+                Text = data.Text,
+                Writer = data.Writer ?? "System",
+                PublishDate = DateTime.Now
+            };
+            await _newsService.Add(news);
+
+            // Update the actionData with the created news ID for snapshot tracking
+            data.CreatedNewsId = news.Id;
+        }
+
+        public async Task Revert(string snapshotData)
+        {
+            var data = JsonSerializer.Deserialize<NewsSnapshotData>(snapshotData, _jsonOptions);
+            if (data.CreatedNewsId.HasValue)
+            {
+                await _newsService.Remove(data.CreatedNewsId.Value);
+            }
+        }
+
+        public string GetConflictKey(string actionData)
+        {
+            // Each news article is unique - use a unique key based on slug
+            var data = JsonSerializer.Deserialize<NewsActionData>(actionData, _jsonOptions);
+            return $"news:{data.Slug ?? data.Title}";
+        }
+
+        private string GenerateSlug(string title)
+        {
+            return title?.ToLower()
+                .Replace(" ", "-")
+                .Replace("'", "")
+                .Replace("\"", "") ?? "campaign-news";
+        }
+    }
+
+    public class NewsActionData
+    {
+        public string Title { get; set; }
+        public string Slug { get; set; }
+        public string Teaser { get; set; }
+        public string Text { get; set; }
+        public string Writer { get; set; }
+        public int? CreatedNewsId { get; set; }
+    }
+
+    public class NewsSnapshotData
+    {
+        public int? CreatedNewsId { get; set; }
+    }
+}

--- a/Services/CampaignActions/RoomCctsActionHandler.cs
+++ b/Services/CampaignActions/RoomCctsActionHandler.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace KeplerCMS.Services.CampaignActions
+{
+    public class RoomCctsActionHandler : ICampaignActionHandler
+    {
+        private readonly DataContext _context;
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public RoomCctsActionHandler(DataContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<string> TakeSnapshot(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<RoomCctsActionData>(actionData, _jsonOptions);
+            var roomIds = data.Rooms.Select(r => r.RoomId).ToList();
+
+            var currentStates = await _context.Rooms
+                .Where(r => roomIds.Contains(r.Id))
+                .Select(r => new RoomCctState
+                {
+                    RoomId = r.Id,
+                    Ccts = r.Casts,
+                    Description = r.Description,
+                    Name = r.Name
+                })
+                .ToListAsync();
+
+            return JsonSerializer.Serialize(new RoomCctsSnapshotData { Rooms = currentStates });
+        }
+
+        public async Task Apply(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<RoomCctsActionData>(actionData, _jsonOptions);
+
+            foreach (var roomChange in data.Rooms)
+            {
+                var room = await _context.Rooms.FindAsync(roomChange.RoomId);
+                if (room != null)
+                {
+                    // Null/empty means "leave this field unchanged"
+                    if (!string.IsNullOrEmpty(roomChange.NewCcts))
+                        room.Casts = roomChange.NewCcts;
+                    if (!string.IsNullOrEmpty(roomChange.NewDescription))
+                        room.Description = roomChange.NewDescription;
+                    if (!string.IsNullOrEmpty(roomChange.NewName))
+                        room.Name = roomChange.NewName;
+                }
+            }
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task Revert(string snapshotData)
+        {
+            var data = JsonSerializer.Deserialize<RoomCctsSnapshotData>(snapshotData, _jsonOptions);
+
+            foreach (var roomState in data.Rooms)
+            {
+                var room = await _context.Rooms.FindAsync(roomState.RoomId);
+                if (room != null)
+                {
+                    room.Casts = roomState.Ccts;
+                    room.Description = roomState.Description;
+                    room.Name = roomState.Name;
+                }
+            }
+
+            await _context.SaveChangesAsync();
+        }
+
+        public string GetConflictKey(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<RoomCctsActionData>(actionData, _jsonOptions);
+            var roomIds = string.Join(",", data.Rooms.Select(r => r.RoomId).OrderBy(id => id));
+            return $"room_ccts:{roomIds}";
+        }
+    }
+
+    public class RoomCctsActionData
+    {
+        public List<RoomCctMapping> Rooms { get; set; } = new List<RoomCctMapping>();
+    }
+
+    public class RoomCctMapping
+    {
+        public int RoomId { get; set; }
+        public string NewCcts { get; set; }
+        public string NewDescription { get; set; }
+        public string NewName { get; set; }
+    }
+
+    public class RoomCctsSnapshotData
+    {
+        public List<RoomCctState> Rooms { get; set; } = new List<RoomCctState>();
+    }
+
+    public class RoomCctState
+    {
+        public int RoomId { get; set; }
+        public string Ccts { get; set; }
+        public string Description { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Services/Implementations/CampaignExecutor.cs
+++ b/Services/Implementations/CampaignExecutor.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Data.Models;
+using KeplerCMS.Models;
+using KeplerCMS.Models.Enums;
+using KeplerCMS.Services.CampaignActions;
+using KeplerCMS.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace KeplerCMS.Services.Implementations
+{
+    public class CampaignExecutor : ICampaignExecutor
+    {
+        private readonly ICampaignService _campaignService;
+        private readonly ICampaignActionHandlerFactory _handlerFactory;
+        private readonly ICommandQueueService _commandQueueService;
+        private readonly ILogger<CampaignExecutor> _logger;
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public CampaignExecutor(
+            ICampaignService campaignService,
+            ICampaignActionHandlerFactory handlerFactory,
+            ICommandQueueService commandQueueService,
+            ILogger<CampaignExecutor> logger)
+        {
+            _campaignService = campaignService;
+            _handlerFactory = handlerFactory;
+            _commandQueueService = commandQueueService;
+            _logger = logger;
+        }
+
+        public async Task ActivateCampaign(int campaignId)
+        {
+            var campaign = await _campaignService.GetById(campaignId);
+            if (campaign == null)
+            {
+                _logger.LogWarning("Campaign {CampaignId} not found", campaignId);
+                return;
+            }
+
+            if (campaign.StatusEnum == CampaignStatus.Active)
+            {
+                _logger.LogWarning("Campaign {CampaignId} is already active", campaignId);
+                return;
+            }
+
+            var activeCampaigns = await _campaignService.GetActiveCampaigns();
+            bool needsCatalogueReload = false;
+            bool needsNavigatorReload = false;
+
+            foreach (var action in campaign.Actions.OrderBy(a => a.OrderIndex))
+            {
+                try
+                {
+                    var handler = _handlerFactory.GetHandler(action.ActionType);
+                    var conflictKey = handler.GetConflictKey(action.ActionData);
+
+                    // Check if another active campaign already manages this setting
+                    string originalData;
+                    var existingSnapshot = activeCampaigns
+                        .SelectMany(c => c.Snapshots)
+                        .FirstOrDefault(s => s.ConflictKey == conflictKey);
+
+                    if (existingSnapshot != null)
+                    {
+                        // Preserve the true original (pre-any-campaign) value
+                        originalData = existingSnapshot.OriginalData;
+                    }
+                    else
+                    {
+                        // No other campaign manages this setting, snapshot current DB state
+                        originalData = await handler.TakeSnapshot(action.ActionData);
+                    }
+
+                    // Save the snapshot
+                    var snapshot = new CampaignSnapshot
+                    {
+                        CampaignId = campaign.Id,
+                        ActionId = action.Id,
+                        ConflictKey = conflictKey,
+                        OriginalData = originalData
+                    };
+                    await _campaignService.SaveSnapshot(snapshot);
+
+                    // Apply the action
+                    await handler.Apply(action.ActionData);
+
+                    // Track what needs reloading
+                    if (action.ActionType == CampaignActionType.CataloguePageVisibility.ToString())
+                        needsCatalogueReload = true;
+                    if (action.ActionType == CampaignActionType.RoomCcts.ToString())
+                        needsNavigatorReload = true;
+
+                    // For news, update the snapshot with the created article ID
+                    if (action.ActionType == CampaignActionType.CreateNews.ToString())
+                    {
+                        var newsData = JsonSerializer.Deserialize<NewsActionData>(action.ActionData, _jsonOptions);
+                        if (newsData.CreatedNewsId.HasValue)
+                        {
+                            snapshot.OriginalData = JsonSerializer.Serialize(
+                                new NewsSnapshotData { CreatedNewsId = newsData.CreatedNewsId });
+                            await _campaignService.SaveSnapshot(snapshot);
+                        }
+                    }
+
+                    _logger.LogInformation("Applied action {ActionType} for campaign {CampaignId}", action.ActionType, campaignId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to apply action {ActionId} ({ActionType}) for campaign {CampaignId}",
+                        action.Id, action.ActionType, campaignId);
+                }
+            }
+
+            // Update campaign status
+            await _campaignService.UpdateStatus(campaignId, CampaignStatus.Active.ToString().ToLower());
+
+            // Send server reload commands
+            SendReloadCommands(needsCatalogueReload, needsNavigatorReload);
+
+            _logger.LogInformation("Campaign {CampaignId} ({Name}) activated successfully", campaignId, campaign.Name);
+        }
+
+        public async Task DeactivateCampaign(int campaignId)
+        {
+            var campaign = await _campaignService.GetById(campaignId);
+            if (campaign == null)
+            {
+                _logger.LogWarning("Campaign {CampaignId} not found", campaignId);
+                return;
+            }
+
+            if (campaign.StatusEnum != CampaignStatus.Active)
+            {
+                _logger.LogWarning("Campaign {CampaignId} is not active (status: {Status})", campaignId, campaign.Status);
+                return;
+            }
+
+            var activeCampaigns = await _campaignService.GetActiveCampaigns();
+            var otherActiveCampaigns = activeCampaigns.Where(c => c.Id != campaignId).ToList();
+
+            bool needsCatalogueReload = false;
+            bool needsNavigatorReload = false;
+
+            // Process actions in reverse order for clean rollback
+            foreach (var action in campaign.Actions.OrderByDescending(a => a.OrderIndex))
+            {
+                try
+                {
+                    var handler = _handlerFactory.GetHandler(action.ActionType);
+                    var conflictKey = handler.GetConflictKey(action.ActionData);
+
+                    // Check if another active campaign also targets this setting
+                    var conflictingCampaign = otherActiveCampaigns
+                        .Where(c => c.Actions.Any(a =>
+                        {
+                            var h = _handlerFactory.GetHandler(a.ActionType);
+                            return h.GetConflictKey(a.ActionData) == conflictKey;
+                        }))
+                        .OrderByDescending(c => c.ActivatedAt)
+                        .FirstOrDefault();
+
+                    if (conflictingCampaign != null)
+                    {
+                        // Another campaign is active for this setting - apply its desired value
+                        var conflictingAction = conflictingCampaign.Actions
+                            .First(a =>
+                            {
+                                var h = _handlerFactory.GetHandler(a.ActionType);
+                                return h.GetConflictKey(a.ActionData) == conflictKey;
+                            });
+                        await handler.Apply(conflictingAction.ActionData);
+                        _logger.LogInformation(
+                            "Conflict on {ConflictKey}: fell back to campaign {FallbackId} value",
+                            conflictKey, conflictingCampaign.Id);
+                    }
+                    else
+                    {
+                        // No other campaign - restore the original value from snapshot
+                        var snapshot = campaign.Snapshots.FirstOrDefault(s => s.ActionId == action.Id);
+                        if (snapshot != null)
+                        {
+                            await handler.Revert(snapshot.OriginalData);
+                        }
+                        else
+                        {
+                            _logger.LogWarning("No snapshot found for action {ActionId} in campaign {CampaignId}",
+                                action.Id, campaignId);
+                        }
+                    }
+
+                    // Track what needs reloading
+                    if (action.ActionType == CampaignActionType.CataloguePageVisibility.ToString())
+                        needsCatalogueReload = true;
+                    if (action.ActionType == CampaignActionType.RoomCcts.ToString())
+                        needsNavigatorReload = true;
+
+                    _logger.LogInformation("Reverted action {ActionType} for campaign {CampaignId}", action.ActionType, campaignId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to revert action {ActionId} ({ActionType}) for campaign {CampaignId}",
+                        action.Id, action.ActionType, campaignId);
+                }
+            }
+
+            // Update campaign status
+            await _campaignService.UpdateStatus(campaignId, CampaignStatus.Ended.ToString().ToLower());
+
+            // Clean up snapshots
+            await _campaignService.RemoveSnapshots(campaignId);
+
+            // Send server reload commands
+            SendReloadCommands(needsCatalogueReload, needsNavigatorReload);
+
+            _logger.LogInformation("Campaign {CampaignId} ({Name}) deactivated successfully", campaignId, campaign.Name);
+        }
+
+        private void SendReloadCommands(bool catalogue, bool navigator)
+        {
+            if (catalogue)
+            {
+                _commandQueueService.QueueCommand(CommandQueueType.reload_catalogue, new CommandTemplate());
+            }
+            if (navigator)
+            {
+                _commandQueueService.QueueCommand(CommandQueueType.reload_navigator, new CommandTemplate());
+            }
+        }
+    }
+}

--- a/Services/Implementations/CampaignService.cs
+++ b/Services/Implementations/CampaignService.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Data;
+using KeplerCMS.Data.Models;
+using KeplerCMS.Models.Enums;
+using KeplerCMS.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace KeplerCMS.Services.Implementations
+{
+    public class CampaignService : ICampaignService
+    {
+        private readonly DataContext _context;
+
+        public CampaignService(DataContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<Campaign>> GetAll()
+        {
+            return await _context.Campaigns
+                .Include(c => c.Actions)
+                .Include(c => c.CreatedBy)
+                .OrderByDescending(c => c.CreatedAt)
+                .ToListAsync();
+        }
+
+        public async Task<Campaign> GetById(int id)
+        {
+            return await _context.Campaigns
+                .Include(c => c.Actions.OrderBy(a => a.OrderIndex))
+                .Include(c => c.Snapshots)
+                .Include(c => c.CreatedBy)
+                .FirstOrDefaultAsync(c => c.Id == id);
+        }
+
+        public async Task<List<Campaign>> GetByStatus(string status)
+        {
+            return await _context.Campaigns
+                .Include(c => c.Actions)
+                .Where(c => c.Status == status)
+                .ToListAsync();
+        }
+
+        public async Task<List<Campaign>> GetActiveCampaigns()
+        {
+            var activeStatus = CampaignStatus.Active.ToString().ToLower();
+            return await _context.Campaigns
+                .Include(c => c.Actions)
+                .Include(c => c.Snapshots)
+                .Where(c => c.Status == activeStatus)
+                .ToListAsync();
+        }
+
+        public async Task<List<Campaign>> GetScheduledCampaignsToActivate()
+        {
+            var scheduledStatus = CampaignStatus.Scheduled.ToString().ToLower();
+            var now = DateTime.Now;
+            return await _context.Campaigns
+                .Include(c => c.Actions)
+                .Where(c => c.Status == scheduledStatus && c.StartDate.HasValue && c.StartDate.Value <= now)
+                .ToListAsync();
+        }
+
+        public async Task<List<Campaign>> GetActiveCampaignsToEnd()
+        {
+            var activeStatus = CampaignStatus.Active.ToString().ToLower();
+            var now = DateTime.Now;
+            return await _context.Campaigns
+                .Include(c => c.Actions)
+                .Include(c => c.Snapshots)
+                .Where(c => c.Status == activeStatus && c.EndDate.HasValue && c.EndDate.Value <= now)
+                .ToListAsync();
+        }
+
+        public async Task<Campaign> Create(Campaign campaign)
+        {
+            campaign.CreatedAt = DateTime.Now;
+            if (campaign.StartDate.HasValue && campaign.StartDate.Value > DateTime.Now)
+            {
+                campaign.StatusEnum = CampaignStatus.Scheduled;
+            }
+            else
+            {
+                campaign.StatusEnum = CampaignStatus.Draft;
+            }
+
+            _context.Campaigns.Add(campaign);
+            await _context.SaveChangesAsync();
+            return campaign;
+        }
+
+        public async Task<Campaign> Update(Campaign campaign)
+        {
+            _context.Campaigns.Update(campaign);
+            await _context.SaveChangesAsync();
+            return campaign;
+        }
+
+        public async Task<bool> Delete(int id)
+        {
+            var campaign = await _context.Campaigns
+                .Include(c => c.Actions)
+                .Include(c => c.Snapshots)
+                .FirstOrDefaultAsync(c => c.Id == id);
+
+            if (campaign == null) return false;
+
+            var activeStatus = CampaignStatus.Active.ToString().ToLower();
+            if (campaign.Status == activeStatus)
+                return false; // Cannot delete an active campaign
+
+            _context.CampaignSnapshots.RemoveRange(campaign.Snapshots);
+            _context.CampaignActions.RemoveRange(campaign.Actions);
+            _context.Campaigns.Remove(campaign);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        public async Task<Campaign> Clone(int campaignId, string newName, int createdById)
+        {
+            var source = await GetById(campaignId);
+            if (source == null) return null;
+
+            var clone = new Campaign
+            {
+                Name = newName,
+                Description = source.Description,
+                StartDate = null,
+                EndDate = null,
+                CreatedAt = DateTime.Now,
+                CreatedById = createdById,
+                ClonedFromId = source.Id
+            };
+            clone.StatusEnum = CampaignStatus.Draft;
+
+            _context.Campaigns.Add(clone);
+            await _context.SaveChangesAsync();
+
+            // Clone actions
+            foreach (var action in source.Actions)
+            {
+                var clonedAction = new CampaignAction
+                {
+                    CampaignId = clone.Id,
+                    ActionType = action.ActionType,
+                    ActionData = action.ActionData,
+                    OrderIndex = action.OrderIndex
+                };
+                _context.CampaignActions.Add(clonedAction);
+            }
+
+            await _context.SaveChangesAsync();
+            return await GetById(clone.Id);
+        }
+
+        public async Task UpdateStatus(int campaignId, string status)
+        {
+            var campaign = await _context.Campaigns.FindAsync(campaignId);
+            if (campaign != null)
+            {
+                campaign.Status = status;
+                if (status == CampaignStatus.Active.ToString().ToLower())
+                {
+                    campaign.ActivatedAt = DateTime.Now;
+                }
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task<CampaignAction> AddAction(CampaignAction action)
+        {
+            _context.CampaignActions.Add(action);
+            await _context.SaveChangesAsync();
+            return action;
+        }
+
+        public async Task<bool> RemoveAction(int actionId)
+        {
+            var action = await _context.CampaignActions.FindAsync(actionId);
+            if (action == null) return false;
+
+            _context.CampaignActions.Remove(action);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        public async Task<CampaignAction> UpdateAction(CampaignAction action)
+        {
+            _context.CampaignActions.Update(action);
+            await _context.SaveChangesAsync();
+            return action;
+        }
+
+        public async Task<List<CampaignAction>> GetActions(int campaignId)
+        {
+            return await _context.CampaignActions
+                .Where(a => a.CampaignId == campaignId)
+                .OrderBy(a => a.OrderIndex)
+                .ToListAsync();
+        }
+
+        public async Task SaveSnapshot(CampaignSnapshot snapshot)
+        {
+            snapshot.CreatedAt = DateTime.Now;
+            _context.CampaignSnapshots.Add(snapshot);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<List<CampaignSnapshot>> GetSnapshots(int campaignId)
+        {
+            return await _context.CampaignSnapshots
+                .Where(s => s.CampaignId == campaignId)
+                .ToListAsync();
+        }
+
+        public async Task RemoveSnapshots(int campaignId)
+        {
+            var snapshots = await _context.CampaignSnapshots
+                .Where(s => s.CampaignId == campaignId)
+                .ToListAsync();
+
+            _context.CampaignSnapshots.RemoveRange(snapshots);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/Services/Implementations/MenuService.cs
+++ b/Services/Implementations/MenuService.cs
@@ -33,7 +33,9 @@ namespace KeplerCMS.Services.Implementations
                 Icon = model.Icon,
                 Href = model.Href,
                 Order = 0,
-                State = model.State
+                State = model.State,
+                StartDate = model.StartDate,
+                EndDate = model.EndDate
             };
             await _context.Menu.AddAsync(menu);
             await _context.SaveChangesAsync();
@@ -58,6 +60,8 @@ namespace KeplerCMS.Services.Implementations
                 item.Icon = model.Icon;
                 item.Href = model.Href;
                 item.State = model.State;
+                item.StartDate = model.StartDate;
+                item.EndDate = model.EndDate;
                 _context.Menu.Update(item);
                 await _context.SaveChangesAsync();
             }

--- a/Services/Implementations/PageService.cs
+++ b/Services/Implementations/PageService.cs
@@ -4,6 +4,7 @@ using KeplerCMS.Data.Models;
 using KeplerCMS.Models;
 using KeplerCMS.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -32,7 +33,10 @@ namespace KeplerCMS.Services.Implementations
             {
                 return null;
             }
-            var containers = await _context.Containers.Where(c => c.PageId == pageDetails.Id && c.IHidden == 0).ToListAsync();
+            var now = DateTime.Now;
+            var containers = await _context.Containers.Where(c => c.PageId == pageDetails.Id && c.IHidden == 0
+                && (c.StartDate == null || c.StartDate <= now)
+                && (c.EndDate == null || c.EndDate >= now)).ToListAsync();
             var news = await _newsService.GetNews(0, 5);
             var promos = await _promoService.GetPromos(pageDetails.Id);
             return new Page { Details = pageDetails, Containers = containers, News = news, Promos = promos };
@@ -92,7 +96,9 @@ namespace KeplerCMS.Services.Implementations
                 Column = model.Column,
                 Theme = model.Theme,
                 Order = 0,
-                Hidden = model.Hidden
+                Hidden = model.Hidden,
+                StartDate = model.StartDate,
+                EndDate = model.EndDate
             };
             await _context.Containers.AddAsync(container);
             await _context.SaveChangesAsync();
@@ -144,7 +150,9 @@ namespace KeplerCMS.Services.Implementations
                 item.Type = model.Type;
                 item.Theme = model.Theme;
                 item.Hidden = model.Hidden;
-                
+                item.StartDate = model.StartDate;
+                item.EndDate = model.EndDate;
+
                 _context.Containers.Update(item);
                 await _context.SaveChangesAsync();
             }

--- a/Services/Interfaces/ICampaignExecutor.cs
+++ b/Services/Interfaces/ICampaignExecutor.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace KeplerCMS.Services.Interfaces
+{
+    public interface ICampaignExecutor
+    {
+        Task ActivateCampaign(int campaignId);
+        Task DeactivateCampaign(int campaignId);
+    }
+}

--- a/Services/Interfaces/ICampaignService.cs
+++ b/Services/Interfaces/ICampaignService.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using KeplerCMS.Data.Models;
+
+namespace KeplerCMS.Services.Interfaces
+{
+    public interface ICampaignService
+    {
+        Task<List<Campaign>> GetAll();
+        Task<Campaign> GetById(int id);
+        Task<List<Campaign>> GetByStatus(string status);
+        Task<List<Campaign>> GetActiveCampaigns();
+        Task<List<Campaign>> GetScheduledCampaignsToActivate();
+        Task<List<Campaign>> GetActiveCampaignsToEnd();
+        Task<Campaign> Create(Campaign campaign);
+        Task<Campaign> Update(Campaign campaign);
+        Task<bool> Delete(int id);
+        Task<Campaign> Clone(int campaignId, string newName, int createdById);
+        Task UpdateStatus(int campaignId, string status);
+        Task<CampaignAction> AddAction(CampaignAction action);
+        Task<bool> RemoveAction(int actionId);
+        Task<CampaignAction> UpdateAction(CampaignAction action);
+        Task<List<CampaignAction>> GetActions(int campaignId);
+        Task SaveSnapshot(CampaignSnapshot snapshot);
+        Task<List<CampaignSnapshot>> GetSnapshots(int campaignId);
+        Task RemoveSnapshots(int campaignId);
+    }
+}

--- a/Startup.cs
+++ b/Startup.cs
@@ -6,6 +6,7 @@ using KeplerCMS.Filters;
 using KeplerCMS.Helpers;
 using KeplerCMS.Hubs;
 using KeplerCMS.Services;
+using KeplerCMS.Services.CampaignActions;
 using KeplerCMS.Services.Implementations;
 using KeplerCMS.Services.Interfaces;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -123,6 +124,16 @@ namespace KeplerCMS
             services.AddScoped<IPollService, PollService>();
             services.AddScoped<ICallsForHelpService, CallsForHelpService>();
 
+            // Campaign system
+            services.AddScoped<ICampaignService, CampaignService>();
+            services.AddScoped<ICampaignExecutor, CampaignExecutor>();
+            services.AddScoped<ICampaignActionHandlerFactory, CampaignActionHandlerFactory>();
+            services.AddScoped<BackgroundActionHandler>();
+            services.AddScoped<BannerActionHandler>();
+            services.AddScoped<NewsActionHandler>();
+            services.AddScoped<CatalogueVisibilityActionHandler>();
+            services.AddScoped<RoomCctsActionHandler>();
+
             services.AddMjmlServices(o =>
             {
                 if (CurrentEnvironment.IsDevelopment())
@@ -147,6 +158,7 @@ namespace KeplerCMS
             });
             
             services.AddHostedService<HabboActivityBackgroundService>();
+            services.AddHostedService<CampaignSchedulerService>();
             
             services.AddSignalR();
         }

--- a/Views/Shared/Containers/News.cshtml
+++ b/Views/Shared/Containers/News.cshtml
@@ -20,7 +20,7 @@
             var promoPages = [
                 @{
                     
-                    var promos = Model.Promos.Where(s => s.Hidden == false).OrderBy(s => s.Order).ToList();
+                    var promos = Model.Promos.Where(s => s.Hidden == false && s.IsScheduledVisible).OrderBy(s => s.Order).ToList();
                     foreach (var promo in promos)
                     {
                         @:{

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -6,7 +6,9 @@
 @inject KeplerCMS.Services.Interfaces.ISettingsService SettingsService
 @{
     var userData = (Users)ViewData["user"];
-    var menu = await MenuService.GetMenu();
+    // Only render menu items inside their scheduled window (start/end dates). Items
+    // with no dates are always shown. Admin menu management still sees every item.
+    var menu = (await MenuService.GetMenu()).Where(m => m.IsScheduledVisible).ToList();
     var settings = await SettingsService.GetAll();
     var subMenu = new List<Menu>();
     var pathList = Context.Request.Path.ToString().Substring(1).Split("/");

--- a/sql/campaigns.sql
+++ b/sql/campaigns.sql
@@ -1,0 +1,101 @@
+-- =====================================================================
+-- Campaign Management System — Production Migration
+-- =====================================================================
+-- Run this ONCE on a production database that does NOT yet have the
+-- campaign feature. It is fully idempotent (safe to re-run): every
+-- statement uses IF NOT EXISTS / INSERT IGNORE / ON DUPLICATE KEY, so
+-- it will not error or duplicate data if parts already exist.
+--
+-- What it creates:
+--   1. cms_campaigns           — campaign definitions + scheduling/status
+--   2. cms_campaign_actions    — ordered actions belonging to a campaign
+--   3. cms_campaign_snapshots  — pre-activation state, for clean rollback
+--   4. fuse_campaigns          — the permission that gates the admin UI
+--   5. rank grants             — gives staff ranks access to that fuse
+--
+-- No existing tables are altered. The feature reads/writes existing
+-- `settings`, `rooms`, `catalogue_pages`, and `news` rows at runtime,
+-- but requires no schema changes to them.
+--
+-- NOTE: the new reload_catalogue / reload_navigator server commands are
+-- RabbitMQ routing keys handled in the Kepler Java server — they need a
+-- server rebuild/deploy, NOT a database change.
+-- =====================================================================
+
+-- ---------------------------------------------------------------------
+-- 1. Campaign definitions
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `cms_campaigns` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `description` text DEFAULT NULL,
+  `start_date` datetime DEFAULT NULL,
+  `end_date` datetime DEFAULT NULL,
+  `status` varchar(50) NOT NULL DEFAULT 'draft',
+  `activated_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `created_by_id` int(11) NOT NULL,
+  `cloned_from_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_status` (`status`),
+  KEY `idx_start_date` (`start_date`),
+  KEY `idx_end_date` (`end_date`),
+  KEY `idx_created_by_id` (`created_by_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------
+-- 2. Campaign actions (the changes a campaign applies)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `cms_campaign_actions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `campaign_id` int(11) NOT NULL,
+  `action_type` varchar(100) NOT NULL,
+  `action_data` text NOT NULL,
+  `order_index` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `idx_campaign_id` (`campaign_id`),
+  CONSTRAINT `fk_campaign_actions_campaign` FOREIGN KEY (`campaign_id`) REFERENCES `cms_campaigns` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------
+-- 3. Campaign snapshots (original values captured for rollback)
+-- ---------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `cms_campaign_snapshots` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `campaign_id` int(11) NOT NULL,
+  `action_id` int(11) NOT NULL,
+  `conflict_key` varchar(255) NOT NULL,
+  `original_data` text NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_campaign_id` (`campaign_id`),
+  KEY `idx_conflict_key` (`conflict_key`),
+  CONSTRAINT `fk_campaign_snapshots_campaign` FOREIGN KEY (`campaign_id`) REFERENCES `cms_campaigns` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_campaign_snapshots_action` FOREIGN KEY (`action_id`) REFERENCES `cms_campaign_actions` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ---------------------------------------------------------------------
+-- 4. Permission (fuse) that gates the Campaigns housekeeping UI
+-- ---------------------------------------------------------------------
+INSERT INTO `fuses` (`fuse`, `user_group`, `description`)
+VALUES ('fuse_campaigns', 'CUSTOM', 'Can manage campaigns')
+ON DUPLICATE KEY UPDATE `description` = VALUES(`description`);
+
+-- ---------------------------------------------------------------------
+-- 5. Grant the fuse to staff ranks.
+--    Mirrors base `housekeeping` access, which is held by:
+--      rank 1 = Hotel Manager, rank 2 = Community Manager
+--    Adjust / remove rows below to match your hotel's rank layout.
+--    (rank 3 = Habbo eXpert is intentionally excluded — campaigns
+--     change live site-wide settings.)
+-- ---------------------------------------------------------------------
+INSERT IGNORE INTO `rank_rights` (`rank_id`, `fuse`) VALUES
+  (1, 'fuse_campaigns'),
+  (2, 'fuse_campaigns');
+
+-- ---------------------------------------------------------------------
+-- Verify (optional — run manually after the migration):
+--   SHOW TABLES LIKE 'cms_campaign%';
+--   SELECT * FROM `fuses` WHERE `fuse` = 'fuse_campaigns';
+--   SELECT * FROM `rank_rights` WHERE `fuse` = 'fuse_campaigns';
+-- =====================================================================

--- a/sql/migrations/2026-06-01_campaigns_and_scheduled_visibility.sql
+++ b/sql/migrations/2026-06-01_campaigns_and_scheduled_visibility.sql
@@ -1,0 +1,112 @@
+-- =====================================================================
+-- RELEASE MIGRATION — 2026-06-01
+-- Campaign management system + scheduled visibility (containers/promos/menu)
+-- =====================================================================
+-- Run this ONCE on a production database that is on the version prior to
+-- these features. It is the single, self-contained script for this release
+-- and supersedes running sql/campaigns.sql and sql/scheduled_visibility.sql
+-- individually (those remain as per-feature references).
+--
+-- Fully idempotent: every statement uses IF NOT EXISTS / INSERT IGNORE /
+-- ON DUPLICATE KEY, so it is safe to re-run.
+--
+-- Sections:
+--   1. Campaign system tables (cms_campaigns, _actions, _snapshots)
+--   2. fuse_campaigns permission + staff rank grants
+--   3. Scheduled-visibility columns on containers, promos and menu items
+--
+-- NOT covered here (deploy separately):
+--   * CMS application binaries (compiled C#).
+--   * Kepler Java server rebuild — the campaign reload_catalogue /
+--     reload_navigator commands and room-data refresh are server code.
+-- =====================================================================
+
+
+-- =====================================================================
+-- 1. Campaign system tables
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS `cms_campaigns` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `description` text DEFAULT NULL,
+  `start_date` datetime DEFAULT NULL,
+  `end_date` datetime DEFAULT NULL,
+  `status` varchar(50) NOT NULL DEFAULT 'draft',
+  `activated_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `created_by_id` int(11) NOT NULL,
+  `cloned_from_id` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_status` (`status`),
+  KEY `idx_start_date` (`start_date`),
+  KEY `idx_end_date` (`end_date`),
+  KEY `idx_created_by_id` (`created_by_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `cms_campaign_actions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `campaign_id` int(11) NOT NULL,
+  `action_type` varchar(100) NOT NULL,
+  `action_data` text NOT NULL,
+  `order_index` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  KEY `idx_campaign_id` (`campaign_id`),
+  CONSTRAINT `fk_campaign_actions_campaign` FOREIGN KEY (`campaign_id`) REFERENCES `cms_campaigns` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `cms_campaign_snapshots` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `campaign_id` int(11) NOT NULL,
+  `action_id` int(11) NOT NULL,
+  `conflict_key` varchar(255) NOT NULL,
+  `original_data` text NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_campaign_id` (`campaign_id`),
+  KEY `idx_conflict_key` (`conflict_key`),
+  CONSTRAINT `fk_campaign_snapshots_campaign` FOREIGN KEY (`campaign_id`) REFERENCES `cms_campaigns` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_campaign_snapshots_action` FOREIGN KEY (`action_id`) REFERENCES `cms_campaign_actions` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- =====================================================================
+-- 2. Permission (fuse) for the Campaigns housekeeping UI + rank grants
+--    Granted to the same staff ranks that hold base `housekeeping`:
+--      rank 1 = Hotel Manager, rank 2 = Community Manager
+--    Adjust the rows below to match your hotel's rank layout.
+-- =====================================================================
+INSERT INTO `fuses` (`fuse`, `user_group`, `description`)
+VALUES ('fuse_campaigns', 'CUSTOM', 'Can manage campaigns')
+ON DUPLICATE KEY UPDATE `description` = VALUES(`description`);
+
+INSERT IGNORE INTO `rank_rights` (`rank_id`, `fuse`) VALUES
+  (1, 'fuse_campaigns'),
+  (2, 'fuse_campaigns');
+
+
+-- =====================================================================
+-- 3. Scheduled visibility — optional start/end windows.
+--    Containers/promos: existing `hidden` flag is a hard off-switch; when
+--    not hidden, the item shows only within its window. Menu items show
+--    only within their window. Empty bound = open-ended; bounds inclusive.
+-- =====================================================================
+ALTER TABLE `cms_containers`
+  ADD COLUMN IF NOT EXISTS `start_date` datetime DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS `end_date` datetime DEFAULT NULL;
+
+ALTER TABLE `cms_promos`
+  ADD COLUMN IF NOT EXISTS `start_date` datetime DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS `end_date` datetime DEFAULT NULL;
+
+ALTER TABLE `cms_menu`
+  ADD COLUMN IF NOT EXISTS `start_date` datetime DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS `end_date` datetime DEFAULT NULL;
+
+-- =====================================================================
+-- Verify (optional):
+--   SHOW TABLES LIKE 'cms_campaign%';
+--   SELECT * FROM `rank_rights` WHERE `fuse` = 'fuse_campaigns';
+--   SHOW COLUMNS FROM `cms_containers` LIKE '%_date';
+--   SHOW COLUMNS FROM `cms_promos`     LIKE '%_date';
+--   SHOW COLUMNS FROM `cms_menu`       LIKE '%_date';
+-- =====================================================================

--- a/sql/scheduled_visibility.sql
+++ b/sql/scheduled_visibility.sql
@@ -1,0 +1,29 @@
+-- =====================================================================
+-- Scheduled visibility for page containers, promos and front-end menu items
+-- =====================================================================
+-- Adds optional start/end date windows so containers, promos and menu
+-- items can be shown only during a set period (e.g. seasonal / Christmas
+-- content).
+--
+-- Visibility rules applied by the CMS at render time:
+--   * Containers: the existing `hidden` flag is a hard off-switch. When a
+--     container is NOT hidden, it shows only if the current time is within
+--     its start/end window. An empty bound is open-ended; bounds inclusive.
+--   * Promos: same rule as containers (`hidden` wins, then the window).
+--   * Menu items: shown only within their start/end window (open-ended if
+--     a bound is empty). Existing `state` (auth) behaviour is unchanged.
+--
+-- Idempotent: uses ADD COLUMN IF NOT EXISTS (MariaDB) — safe to re-run.
+-- =====================================================================
+
+ALTER TABLE `cms_containers`
+  ADD COLUMN IF NOT EXISTS `start_date` datetime DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS `end_date` datetime DEFAULT NULL;
+
+ALTER TABLE `cms_promos`
+  ADD COLUMN IF NOT EXISTS `start_date` datetime DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS `end_date` datetime DEFAULT NULL;
+
+ALTER TABLE `cms_menu`
+  ADD COLUMN IF NOT EXISTS `start_date` datetime DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS `end_date` datetime DEFAULT NULL;


### PR DESCRIPTION
…s/menu

Campaign system (Housekeeping):
- New cms_campaigns / cms_campaign_actions / cms_campaign_snapshots tables with EF models and a Campaigns admin area (list/create/edit, add/edit/ remove actions, activate/deactivate, clone, delete).
- Pluggable action handlers (background, banner, news, catalogue page visibility, room CCTs + title/description) behind ICampaignActionHandler, resolved via CampaignActionHandlerFactory.
- CampaignExecutor applies actions with per-setting snapshots and conflict resolution across overlapping campaigns; clean revert on deactivate.
- CampaignSchedulerService auto-activates/ends campaigns by start/end date.
- Queues reload_catalogue / reload_navigator to the game server after catalogue/room changes. Gated by the new fuse_campaigns permission.

Scheduled visibility:
- Optional start/end date windows on page containers, promos and front-end menu items. Manual "hidden" stays a hard off-switch; dates gate the rest. Bounds inclusive, open-ended when blank. Admin retains full visibility.
- Reuses the shared jQuery datetimepicker for a consistent admin UX.

Migrations: sql/campaigns.sql, sql/scheduled_visibility.sql, and a consolidated, idempotent
sql/migrations/2026-06-01_campaigns_and_scheduled_visibility.sql.