### PR TITLE
feat: catalogue rare-item campaign action + housekeeping server-statu…

### DIFF
--- a/Areas/Housekeeping/Views/Campaigns/Edit.cshtml
+++ b/Areas/Housekeeping/Views/Campaigns/Edit.cshtml
@@ -344,6 +344,8 @@
     <link rel="stylesheet" href="~/lib/select2/css/select2.min.css" />
     <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
     <script src="~/lib/select2/js/select2.min.js"></script>
+    <script src="~/housekeeping/js/tinymce/tinymce.min.js"></script>
+    <script src="~/housekeeping/js/tinymce/jquery.tinymce.min.js"></script>
     <script>
         // Renders a furni image preview next to each search result (mirrors the Rewards picker).
         function formatState(state) {
@@ -363,6 +365,21 @@
             var datetimeSettings = { format: 'Y-m-d H:i:s' };
             $("#startDatepicker").datetimepicker(datetimeSettings);
             $("#endDatepicker").datetimepicker(datetimeSettings);
+
+            // Rich text editor for the Create News action body (matches the News admin pages)
+            $('#news-text').tinymce({
+                relative_urls: false,
+                convert_urls: false,
+                remove_script_host: false,
+                forced_root_block: '',
+                force_br_newlines: true,
+                force_p_newlines: false,
+                plugins: [
+                    "advlist autolink lists link image charmap print preview anchor",
+                    "searchreplace visualblocks code fullscreen",
+                    "insertdatetime media table paste imagetools wordcount"
+                ]
+            });
 
             $('#rare-item-searcher').select2({
                 templateResult: formatState,
@@ -437,7 +454,11 @@
                     document.getElementById('news-slug').value = data.slug || '';
                     document.getElementById('news-teaser').value = data.teaser || '';
                     document.getElementById('news-writer').value = data.writer || '';
-                    document.getElementById('news-text').value = data.text || '';
+                    if (window.tinymce && tinymce.get('news-text')) {
+                        tinymce.get('news-text').setContent(data.text || '');
+                    } else {
+                        document.getElementById('news-text').value = data.text || '';
+                    }
                     break;
                 case 'CataloguePageVisibility':
                     document.querySelectorAll('.catalogue-page-check').forEach(function (cb) { cb.checked = false; });
@@ -505,12 +526,15 @@
                     actionData = { value: document.getElementById('banner-value').value };
                     break;
                 case 'CreateNews':
+                    var newsBody = (window.tinymce && tinymce.get('news-text'))
+                        ? tinymce.get('news-text').getContent()
+                        : document.getElementById('news-text').value;
                     actionData = {
                         title: document.getElementById('news-title').value,
                         slug: document.getElementById('news-slug').value,
                         teaser: document.getElementById('news-teaser').value,
                         writer: document.getElementById('news-writer').value,
-                        text: document.getElementById('news-text').value
+                        text: newsBody
                     };
                     break;
                 case 'CataloguePageVisibility':

--- a/Areas/Housekeeping/Views/Campaigns/Edit.cshtml
+++ b/Areas/Housekeeping/Views/Campaigns/Edit.cshtml
@@ -130,6 +130,7 @@
                             <option value="CreateNews">Create News Article</option>
                             <option value="CataloguePageVisibility">Catalogue Page Visibility</option>
                             <option value="RoomCcts">Room CCTs</option>
+                            <option value="CatalogueRareItem">Catalogue Rare Item</option>
                         </select>
                     </div>
 
@@ -261,6 +262,16 @@
                         </table>
                         <button class="btn btn-sm btn-success action-submit-btn mt-2" onclick="submitAction('RoomCcts')">Add Action</button>
                     </div>
+
+                    <!-- Catalogue Rare Item Form -->
+                    <div id="form-CatalogueRareItem" class="action-form" style="display:none;">
+                        <p class="text-muted">Pick the furni sold as the catalogue rare item while this campaign is active. The rare page is shown to everyone (DEFAULT) when the campaign is active and hidden (admin only) when it ends.</p>
+                        <div class="form-group">
+                            <label class="label-control">Rare item</label>
+                            <select id="rare-item-searcher" class="furni-searcher form-control" style="width:100%;"></select>
+                        </div>
+                        <button class="btn btn-sm btn-success action-submit-btn mt-2" onclick="submitAction('CatalogueRareItem')">Add Action</button>
+                    </div>
                 </div>
             </div>
         }
@@ -330,12 +341,46 @@
 
 @section scripts {
     <link rel="stylesheet" href="~/lib/datetimepicker/jquery.datetimepicker.min.css">
+    <link rel="stylesheet" href="~/lib/select2/css/select2.min.css" />
     <script src="~/lib/datetimepicker/jquery.datetimepicker.full.js"></script>
+    <script src="~/lib/select2/js/select2.min.js"></script>
     <script>
+        // Renders a furni image preview next to each search result (mirrors the Rewards picker).
+        function formatState(state) {
+            if (!state.id) {
+                return state.text;
+            }
+            var matches = /\(([^)]+)\)/.exec(state.text);
+            if (!matches) { return state.text; }
+            var rawSprite = matches[1];
+            var sprite = rawSprite.includes("*") ? rawSprite.split("*")[0] : rawSprite;
+            var color = rawSprite.includes("*") ? "&s=true&color=" + rawSprite.split("*")[1] : "&icon=true";
+            var img = "https://habbo-danmark.com/habbo-imaging/furni?sprite=" + sprite + color;
+            return $('<span><img src="' + img + '" /> ' + state.text + '</span>');
+        }
+
         $(document).ready(function () {
             var datetimeSettings = { format: 'Y-m-d H:i:s' };
             $("#startDatepicker").datetimepicker(datetimeSettings);
             $("#endDatepicker").datetimepicker(datetimeSettings);
+
+            $('#rare-item-searcher').select2({
+                templateResult: formatState,
+                placeholder: 'Search for a furni...',
+                ajax: {
+                    url: '/api/hotel/furni/search',
+                    dataType: 'json',
+                    delay: 250,
+                    data: function (params) { return { query: params.term }; },
+                    processResults: function (data) {
+                        return {
+                            results: data.map(function (item) {
+                                return { id: item.id, text: "(" + item.sprite + ") " + item.name };
+                            })
+                        };
+                    }
+                }
+            });
 
             document.querySelectorAll('.edit-action-btn').forEach(function (btn) {
                 btn.addEventListener('click', function () {
@@ -421,6 +466,14 @@
                         if (desc) desc.value = r.newDescription || '';
                     });
                     break;
+                case 'CatalogueRareItem':
+                    var $rare = $('#rare-item-searcher');
+                    $rare.empty();
+                    if (data.definitionId) {
+                        var label = data.label || ('#' + data.definitionId);
+                        $rare.append(new Option(label, data.definitionId, true, true)).trigger('change');
+                    }
+                    break;
             }
         }
 
@@ -500,6 +553,14 @@
                     }
                     actionData = { rooms: rooms };
                     break;
+                case 'CatalogueRareItem':
+                    var rareData = $('#rare-item-searcher').select2('data');
+                    if (!rareData || rareData.length === 0 || !rareData[0].id) {
+                        alert('Please select a rare item');
+                        return;
+                    }
+                    actionData = { definitionId: parseInt(rareData[0].id), label: rareData[0].text };
+                    break;
             }
 
             // Submit via form
@@ -564,6 +625,10 @@
                     var roomData = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(action.ActionData);
                     var roomCount = roomData.GetProperty("rooms").GetArrayLength();
                     return $"Update CCTs for {roomCount} room(s)";
+                case "CatalogueRareItem":
+                    var rareData = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(action.ActionData);
+                    var rareLabel = rareData.TryGetProperty("label", out var lbl) ? lbl.GetString() : "?";
+                    return $"Set rare item to: {rareLabel}";
                 default:
                     return action.ActionType;
             }

--- a/Areas/Housekeeping/Views/Shared/_Housekeeping.cshtml
+++ b/Areas/Housekeeping/Views/Shared/_Housekeeping.cshtml
@@ -3,6 +3,7 @@
 @using KeplerCMS.Areas.Housekeeping.Models.Enums
 @using Microsoft.AspNetCore.Html
 @using KeplerCMS.Areas.Housekeeping.Models.Views
+@inject KeplerCMS.Services.Interfaces.ISettingsService SettingsService
 @{
     var userData = (Users)ViewData["user"];
     var path = Context.Request.Path;
@@ -88,6 +89,44 @@
     <div class="content">
         <div class="sidebar">
             @{
+                if (activeMenuItem == HousekeepingMenu.Home)
+                {
+                    var onlineSetting = await SettingsService.Get("players.online", "0");
+                    <div class="container">
+                        <div class="title">
+                            Server status
+                        </div>
+                        <div class="container-content">
+                            <ul>
+                                <li>Server time: <strong id="hk-server-time">@DateTime.Now.ToString("HH:mm:ss")</strong></li>
+                                <li>Habbos online: <strong id="hk-online-count">@onlineSetting.Value</strong></li>
+                            </ul>
+                        </div>
+                    </div>
+                    <script>
+                        (function () {
+                            // Live server clock, seeded from the server-rendered time
+                            var t = new Date(@DateTime.Now.Year, @(DateTime.Now.Month - 1), @DateTime.Now.Day, @DateTime.Now.Hour, @DateTime.Now.Minute, @DateTime.Now.Second);
+                            function pad(n) { return n < 10 ? '0' + n : n; }
+                            setInterval(function () {
+                                t.setSeconds(t.getSeconds() + 1);
+                                var el = document.getElementById('hk-server-time');
+                                if (el) el.textContent = pad(t.getHours()) + ':' + pad(t.getMinutes()) + ':' + pad(t.getSeconds());
+                            }, 1000);
+                            // Refresh the online count periodically
+                            setInterval(function () {
+                                fetch('/api/hotel/online')
+                                    .then(function (r) { return r.text(); })
+                                    .then(function (v) {
+                                        var el = document.getElementById('hk-online-count');
+                                        if (el) el.textContent = v;
+                                    })
+                                    .catch(function () { });
+                            }, 30000);
+                        })();
+                    </script>
+                }
+
                 if (activeMenuItem == HousekeepingMenu.WebsiteAdmin)
                 {
                     <div class="container">

--- a/Models/Enums/CampaignActionType.cs
+++ b/Models/Enums/CampaignActionType.cs
@@ -6,6 +6,7 @@ namespace KeplerCMS.Models.Enums
         ChangeBanner,
         CreateNews,
         CataloguePageVisibility,
-        RoomCcts
+        RoomCcts,
+        CatalogueRareItem
     }
 }

--- a/Services/CampaignActions/CampaignActionHandlerFactory.cs
+++ b/Services/CampaignActions/CampaignActionHandlerFactory.cs
@@ -32,6 +32,7 @@ namespace KeplerCMS.Services.CampaignActions
                 CampaignActionType.CreateNews => _serviceProvider.GetRequiredService<NewsActionHandler>(),
                 CampaignActionType.CataloguePageVisibility => _serviceProvider.GetRequiredService<CatalogueVisibilityActionHandler>(),
                 CampaignActionType.RoomCcts => _serviceProvider.GetRequiredService<RoomCctsActionHandler>(),
+                CampaignActionType.CatalogueRareItem => _serviceProvider.GetRequiredService<CatalogueRareItemActionHandler>(),
                 _ => throw new ArgumentException($"No handler registered for action type: {actionType}")
             };
         }

--- a/Services/CampaignActions/CatalogueRareItemActionHandler.cs
+++ b/Services/CampaignActions/CatalogueRareItemActionHandler.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using KeplerCMS.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace KeplerCMS.Services.CampaignActions
+{
+    /// <summary>
+    /// Campaign action that controls the catalogue "rare item" (the single
+    /// catalogue_items row with sale_code = 'rare_item') and the visibility of
+    /// its page. While the campaign is active the page fuse is DEFAULT (visible
+    /// to all) and the rare item sells the chosen definition. When the campaign
+    /// ends, the page fuse is set to fuse_catalogue_administrator (hidden); the
+    /// last-set definition is intentionally left in place.
+    /// </summary>
+    public class CatalogueRareItemActionHandler : ICampaignActionHandler
+    {
+        private readonly DataContext _context;
+        private const string RareSaleCode = "rare_item";
+        private const string ActiveFuse = "DEFAULT";
+        private const string HiddenFuse = "fuse_catalogue_administrator";
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public CatalogueRareItemActionHandler(DataContext context)
+        {
+            _context = context;
+        }
+
+        public Task<string> TakeSnapshot(string actionData)
+        {
+            // The definition_id is intentionally kept on deactivate (only the page
+            // is hidden), so there is no prior state to capture.
+            return Task.FromResult("{}");
+        }
+
+        public async Task Apply(string actionData)
+        {
+            var data = JsonSerializer.Deserialize<CatalogueRareItemActionData>(actionData, _jsonOptions);
+
+            // Update the rare item's definition via raw SQL. The CatalogueItems entity
+            // maps a non-existent "sprite" column, so materializing it would fail;
+            // a raw UPDATE avoids that.
+            await _context.Database.ExecuteSqlRawAsync(
+                "UPDATE catalogue_items SET definition_id = {0} WHERE sale_code = {1}",
+                data.DefinitionId, RareSaleCode);
+
+            await SetRarePageFuse(ActiveFuse);
+        }
+
+        public async Task Revert(string snapshotData)
+        {
+            // Hide the rare page again; leave the last-set definition_id untouched.
+            await SetRarePageFuse(HiddenFuse);
+        }
+
+        public string GetConflictKey(string actionData)
+        {
+            return "catalogue_rare_item";
+        }
+
+        private async Task SetRarePageFuse(string fuse)
+        {
+            // Read only the page id (projection) to avoid materializing CatalogueItems.
+            var pageId = await _context.CatalogueItems
+                .Where(c => c.SaleCode == RareSaleCode)
+                .Select(c => c.PageId)
+                .FirstOrDefaultAsync();
+
+            if (string.IsNullOrEmpty(pageId) || !int.TryParse(pageId, out var pageIdInt))
+                return;
+
+            var page = await _context.CataloguePages.FindAsync(pageIdInt);
+            if (page != null)
+            {
+                page.Fuse = fuse;
+                await _context.SaveChangesAsync();
+            }
+        }
+    }
+
+    public class CatalogueRareItemActionData
+    {
+        public int DefinitionId { get; set; }
+        // Display text from the furni picker ("(sprite) name"), used for the
+        // action summary and for re-populating the picker when editing.
+        public string Label { get; set; }
+    }
+}

--- a/Services/Implementations/CampaignExecutor.cs
+++ b/Services/Implementations/CampaignExecutor.cs
@@ -91,7 +91,8 @@ namespace KeplerCMS.Services.Implementations
                     await handler.Apply(action.ActionData);
 
                     // Track what needs reloading
-                    if (action.ActionType == CampaignActionType.CataloguePageVisibility.ToString())
+                    if (action.ActionType == CampaignActionType.CataloguePageVisibility.ToString()
+                        || action.ActionType == CampaignActionType.CatalogueRareItem.ToString())
                         needsCatalogueReload = true;
                     if (action.ActionType == CampaignActionType.RoomCcts.ToString())
                         needsNavigatorReload = true;
@@ -195,7 +196,8 @@ namespace KeplerCMS.Services.Implementations
                     }
 
                     // Track what needs reloading
-                    if (action.ActionType == CampaignActionType.CataloguePageVisibility.ToString())
+                    if (action.ActionType == CampaignActionType.CataloguePageVisibility.ToString()
+                        || action.ActionType == CampaignActionType.CatalogueRareItem.ToString())
                         needsCatalogueReload = true;
                     if (action.ActionType == CampaignActionType.RoomCcts.ToString())
                         needsNavigatorReload = true;

--- a/Startup.cs
+++ b/Startup.cs
@@ -133,6 +133,7 @@ namespace KeplerCMS
             services.AddScoped<NewsActionHandler>();
             services.AddScoped<CatalogueVisibilityActionHandler>();
             services.AddScoped<RoomCctsActionHandler>();
+            services.AddScoped<CatalogueRareItemActionHandler>();
 
             services.AddMjmlServices(o =>
             {


### PR DESCRIPTION
…s panel

Catalogue Rare Item action:
- New CatalogueRareItem campaign action type. Picks the catalogue rare item (the catalogue_items row with sale_code 'rare_item') via the same furni picker as the Rewards screen (AJAX /api/hotel/furni/search + image preview).
- On activate: applies the chosen definition_id and sets the rare page fuse to DEFAULT (visible to all). On deactivate: hides the page (fuse_catalogue_administrator), keeping the last-set definition.
- Queues reload_catalogue. Reads page id via projection and updates the definition via raw SQL to avoid the phantom catalogue_items.sprite mapping.
- Wired through the enum, handler factory, DI, executor reload routing, and the campaign Edit UI (option, picker form, submit/populate/summary).

Housekeeping front page:
- Add a "Server status" sidebar panel (Home only) showing a live server clock and the current Habbos-online count (players.online, refreshed via /api/hotel/online).