### PR TITLE
feat: upgrade to .NET 10

### DIFF
--- a/.claude/skills/habbo-cms-features/SKILL.md
+++ b/.claude/skills/habbo-cms-features/SKILL.md
@@ -36,7 +36,7 @@ Reference these guidelines when:
 
 | Component | Technology |
 |-----------|-----------|
-| Language | C# (.NET 6.0) |
+| Language | C# (.NET 10.0) |
 | Framework | ASP.NET Core MVC |
 | Views | Razor (.cshtml) |
 | Database | MySQL via Entity Framework Core |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/net6.0/KeplerCMS.dll",
+            "program": "${workspaceFolder}/bin/Debug/net10.0/KeplerCMS.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/Controllers/PhotoController.cs
+++ b/Controllers/PhotoController.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using KeplerCMS.Helpers;
 using System;
 using System.IO;
-using System.Drawing.Imaging;
 using System.Net.Http.Headers;
 using System.Net.Http;
 using System.Web;

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -37,6 +37,11 @@ namespace KeplerCMS.Data
                 .HasOne(r => r.Owner)
                 .WithOne()
                 .HasForeignKey<Rooms>(r => r.OwnerId);
+
+            // Replaces the [MySqlCollation] attribute removed from MySql.EntityFrameworkCore
+            modelBuilder.Entity<Rooms>()
+                .Property(r => r.Model)
+                .UseCollation("utf8mb4_bin");
             
             modelBuilder.Entity<RoomChatlogs>()
                 .HasOne(r => r.Room)

--- a/Data/Models/RoomChatlogs.cs
+++ b/Data/Models/RoomChatlogs.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
-using MySql.EntityFrameworkCore.DataAnnotations;
 
 namespace KeplerCMS.Data.Models
 {

--- a/Data/Models/Rooms.cs
+++ b/Data/Models/Rooms.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
-using MySql.EntityFrameworkCore.DataAnnotations;
 
 namespace KeplerCMS.Data.Models
 {
@@ -26,7 +25,6 @@ namespace KeplerCMS.Data.Models
         [Column("category")]
         public int Category { get; set; }
         [Column("model")]
-        [MySqlCollation("utf8mb4_bin")]
         public string Model { get; set; }
         [Column("ccts")]
         public string Casts { get; set; }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,6 @@
-#FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-env
-#WORKDIR /app
-
-# Copy csproj and restore as distinct layers
-#COPY *.csproj ./
-#RUN dotnet restore
-
-# Copy everything else and build
-#COPY . ./
-#RUN dotnet publish -c Release -o out
-
-# Build runtime image
-#FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
-#WORKDIR /app
-#COPY --from=build-env /app/out .
-#ENTRYPOINT ["dotnet", "KeplerCMS.dll"]
-
-
 # Stage 1
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /build
 EXPOSE 80
 EXPOSE 443
@@ -27,17 +9,14 @@ RUN dotnet restore -v diag
 RUN dotnet publish -c Release -o /app
 
 # Stage 2
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-focal AS final
-RUN apt-get update \
-    && apt-get install -y --allow-unauthenticated \
-        #libc6-dev \
-        libgdiplus 
-        #libx11-dev \
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 RUN apt-get update && apt-get install -y --allow-unauthenticated curl
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 RUN apt-get install -y --allow-unauthenticated nodejs
-RUN  rm -rf /var/lib/apt/lists/*
+RUN rm -rf /var/lib/apt/lists/*
 ENV TZ="Europe/Copenhagen"
+# .NET 8+ aspnet images default to port 8080; keep listening on 80 as before
+ENV ASPNETCORE_HTTP_PORTS=80
 WORKDIR /app
 COPY --from=build /app .
 ENTRYPOINT ["dotnet", "KeplerCMS.dll"]

--- a/KeplerCMS.csproj
+++ b/KeplerCMS.csproj
@@ -1,8 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
+    <!-- The .NET 9+ SDK precompresses wwwroot assets (.br/.gz) on publish. The Avatara/Chroma
+         FileUtil directory scans match files by name-contains and would pick up the compressed
+         copies; the app serves via UseStaticFiles, which never uses them. Keep this disabled. -->
+    <CompressionEnabled>false</CompressionEnabled>
     <UserSecretsId>14598647-2251-4f6b-8f7f-ff9e5647f6ec</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
@@ -92,20 +96,18 @@
 
   <ItemGroup>
     <PackageReference Include="FluentEmail.Mailgun" Version="3.0.2" />
-    <PackageReference Include="Isopoh.Cryptography.Argon2" Version="1.1.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
+    <PackageReference Include="Isopoh.Cryptography.Argon2" Version="1.1.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.9" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="Mjml.AspNetCore" Version="1.3.0" />
-    <PackageReference Include="MySql.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Narochno.BBCode" Version="2.1.0" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="4.9.0" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="Westwind.Globalization.AspnetCore" Version="3.1.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="Sentry.AspNetCore" Version="6.6.0" />
+    <PackageReference Include="Westwind.Globalization.AspnetCore" Version="3.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Libraries/Avatara/Avatar.cs
+++ b/Libraries/Avatara/Avatar.cs
@@ -7,7 +7,6 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -235,20 +234,16 @@ namespace KeplerCMS.Avatara
                     finalCanvas = this.FaceCanvas;
                 }
 
-                using (Bitmap tempBitmap = finalCanvas.ToBitmap())
+                if (!RenderEntireFigure)
                 {
-                    if (!RenderEntireFigure)
+                    using (var trimmed = ImageUtil.Trim(finalCanvas))
                     {
-                        using (var bitmap = ImageUtil.TrimBitmap(tempBitmap))
-                        {
-                            return RenderImage(bitmap);
-                        }
+                        return RenderImage(trimmed);
                     }
-                    else
-                    {
-                        // Crop the image
-                        return RenderImage(tempBitmap);
-                    }
+                }
+                else
+                {
+                    return RenderImage(finalCanvas);
                 }
             }
         }
@@ -328,24 +323,23 @@ namespace KeplerCMS.Avatara
             }
         }
 
-        private byte[] RenderImage(Bitmap croppedBitmap)
+        private byte[] RenderImage(Image<Rgba32> croppedImage)
         {
             if (Size == "l")
             {
-                using (var image = croppedBitmap.ToImageSharpImage<Rgba32>())
+                var resizeOptions = new ResizeOptions();
+                resizeOptions.Size = new SixLabors.ImageSharp.Size(
+                   croppedImage.Width * 2, croppedImage.Height * 2
+                );
+
+                resizeOptions.Sampler = KnownResamplers.NearestNeighbor;
+
+                using (var image = croppedImage.Clone(x => x.Resize(resizeOptions)))
                 {
-                    var resizeOptions = new ResizeOptions();
-                    resizeOptions.Size = new SixLabors.ImageSharp.Size(
-                       image.Width * 2, image.Height * 2
-                    );
-
-                    resizeOptions.Sampler = KnownResamplers.NearestNeighbor;
-                    image.Mutate(x => x.Resize(resizeOptions));
-
-                    return image.ToBitmap().ToByteArray();
+                    return image.ToByteArray();
                 }
             }
-            return croppedBitmap.ToByteArray();
+            return croppedImage.ToByteArray();
         }
 
         private List<AvatarAsset> BuildDrawQueue()

--- a/Libraries/Avatara/Extensions/ImageSharpExtensions.cs
+++ b/Libraries/Avatara/Extensions/ImageSharpExtensions.cs
@@ -1,49 +1,16 @@
-﻿using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
-using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KeplerCMS.Avatara.Extensions
 {
     public static class ImageSharpExtensions
     {
-        public static System.Drawing.Bitmap ToBitmap<Rgba32>(this Image<Rgba32> image) where Rgba32 : unmanaged, IPixel<Rgba32>
-        {
-            using (var memoryStream = new MemoryStream())
-            {
-                var imageEncoder = Configuration.Default.ImageFormatsManager.GetEncoder(PngFormat.Instance);
-                image.Save(memoryStream, imageEncoder);
-
-                memoryStream.Seek(0, SeekOrigin.Begin);
-
-                return new System.Drawing.Bitmap(memoryStream);
-            }
-        }
-
-        public static Image<Rgba32> ToImageSharpImage<Rgba32>(this System.Drawing.Bitmap bitmap) where Rgba32 : unmanaged, IPixel<Rgba32>
-        {
-            using (var memoryStream = new MemoryStream())
-            {
-                bitmap.Save(memoryStream, System.Drawing.Imaging.ImageFormat.Png);
-
-                memoryStream.Seek(0, SeekOrigin.Begin);
-
-                return SixLabors.ImageSharp.Image.Load<Rgba32>(memoryStream);
-            }
-        }
-
-        public static byte[] ToByteArray(this Bitmap bitmap)
+        public static byte[] ToByteArray<TPixel>(this Image<TPixel> image) where TPixel : unmanaged, IPixel<TPixel>
         {
             using (MemoryStream ms = new MemoryStream())
             {
-                bitmap.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                image.SaveAsPng(ms);
 
                 return ms.ToArray();
             }

--- a/Libraries/Avatara/FigureExtractor.cs
+++ b/Libraries/Avatara/FigureExtractor.cs
@@ -2,7 +2,6 @@
 using KeplerCMS.Avatara.Util;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/Libraries/Avatara/Util/ImageUtil.cs
+++ b/Libraries/Avatara/Util/ImageUtil.cs
@@ -1,20 +1,21 @@
-﻿﻿using SixLabors.ImageSharp.PixelFormats;
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 using System;
-using System.Drawing;
 
 namespace KeplerCMS.Avatara.Util
 {
     public class ImageUtil
     {
-        public static Bitmap TrimBitmap(Bitmap bmp)
+        public static Image<Rgba32> Trim(Image<Rgba32> image)
         {
-            int w = bmp.Width;
-            int h = bmp.Height;
+            int w = image.Width;
+            int h = image.Height;
 
             Func<int, bool> allWhiteRow = r =>
             {
                 for (int i = 0; i < w; ++i)
-                    if ((bmp.GetPixel(i, r).A != 0))
+                    if ((image[i, r].A != 0))
                         return false;
                 return true;
             };
@@ -22,7 +23,7 @@ namespace KeplerCMS.Avatara.Util
             Func<int, bool> allWhiteColumn = c =>
             {
                 for (int i = 0; i < h; ++i)
-                    if ((bmp.GetPixel(c, i).A != 0))
+                    if ((image[c, i].A != 0))
                         return false;
                 return true;
             };
@@ -78,15 +79,7 @@ namespace KeplerCMS.Avatara.Util
 
             try
             {
-                var target = new Bitmap(croppedWidth, croppedHeight);
-                using (Graphics g = Graphics.FromImage(target))
-                {
-                    g.DrawImage(bmp,
-                      new System.Drawing.RectangleF(0, 0, croppedWidth, croppedHeight),
-                      new System.Drawing.RectangleF(leftmost, topmost, croppedWidth, croppedHeight),
-                      GraphicsUnit.Pixel);
-                }
-                return target;
+                return image.Clone(ctx => ctx.Crop(new Rectangle(leftmost, topmost, croppedWidth, croppedHeight)));
             }
             catch (Exception ex)
             {
@@ -96,16 +89,16 @@ namespace KeplerCMS.Avatara.Util
             }
         }
 
-        public static Bitmap TrimBitmap(Bitmap bmp, params Rgba32[] colors)
+        public static Image<Rgba32> Trim(Image<Rgba32> image, params Rgba32[] colors)
         {
-            int w = bmp.Width;
-            int h = bmp.Height;
+            int w = image.Width;
+            int h = image.Height;
 
 
             int topmost = 0;
             for (int row = 0; row < h; ++row)
             {
-                if (!allWhiteRow(bmp, row, colors))
+                if (!allWhiteRow(image, row, colors))
                     break;
                 topmost = row;
             }
@@ -113,7 +106,7 @@ namespace KeplerCMS.Avatara.Util
             int bottommost = 0;
             for (int row = h - 1; row >= 0; --row)
             {
-                if (!allWhiteRow(bmp, row, colors))
+                if (!allWhiteRow(image, row, colors))
                     break;
                 bottommost = row;
             }
@@ -121,14 +114,14 @@ namespace KeplerCMS.Avatara.Util
             int leftmost = 0, rightmost = 0;
             for (int col = 0; col < w; ++col)
             {
-                if (!allWhiteCol(bmp, col, colors))
+                if (!allWhiteCol(image, col, colors))
                     break;
                 leftmost = col;
             }
 
             for (int col = w - 1; col >= 0; --col)
             {
-                if (!allWhiteCol(bmp, col, colors))
+                if (!allWhiteCol(image, col, colors))
                     break;
                 rightmost = col;
             }
@@ -153,15 +146,7 @@ namespace KeplerCMS.Avatara.Util
 
             try
             {
-                var target = new Bitmap(croppedWidth, croppedHeight);
-                using (Graphics g = Graphics.FromImage(target))
-                {
-                    g.DrawImage(bmp,
-                      new System.Drawing.RectangleF(0, 0, croppedWidth, croppedHeight),
-                      new System.Drawing.RectangleF(leftmost, topmost, croppedWidth, croppedHeight),
-                      GraphicsUnit.Pixel);
-                }
-                return target;
+                return image.Clone(ctx => ctx.Crop(new Rectangle(leftmost, topmost, croppedWidth, croppedHeight)));
             }
             catch (Exception ex)
             {
@@ -171,14 +156,13 @@ namespace KeplerCMS.Avatara.Util
             }
         }
 
-        private static bool allWhiteRow(Bitmap bmp, int r, params Rgba32[] colors)
+        private static bool allWhiteRow(Image<Rgba32> image, int r, params Rgba32[] colors)
         {
-            int w = bmp.Width;
-            int h = bmp.Height;
+            int w = image.Width;
 
             for (int i = 0; i < w; ++i)
             {
-                var pixel = bmp.GetPixel(i, r);
+                var pixel = image[i, r];
 
                 if (!ColorEquals(colors, pixel))
                 {
@@ -189,14 +173,13 @@ namespace KeplerCMS.Avatara.Util
             return true;
         }
 
-        private static bool allWhiteCol(Bitmap bmp, int c, params Rgba32[] colors)
+        private static bool allWhiteCol(Image<Rgba32> image, int c, params Rgba32[] colors)
         {
-            int w = bmp.Width;
-            int h = bmp.Height;
+            int h = image.Height;
 
             for (int i = 0; i < h; ++i)
             {
-                var pixel = bmp.GetPixel(c, i);
+                var pixel = image[c, i];
 
                 if (!ColorEquals(colors, pixel))
                 {
@@ -207,7 +190,7 @@ namespace KeplerCMS.Avatara.Util
             return true;
         }
 
-        private static bool ColorEquals(Rgba32[] colors, System.Drawing.Color pixel)
+        private static bool ColorEquals(Rgba32[] colors, Rgba32 pixel)
         {
             foreach (var color in colors)
             {

--- a/Libraries/Chroma/ChromaAsset.cs
+++ b/Libraries/Chroma/ChromaAsset.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.IO;
 using System.Xml;
 using System.Linq;
@@ -130,12 +129,10 @@ namespace KeplerCMS.Chroma
                 {
                     if (flipH)
                     {
-                        var bitmap1 = (Bitmap)Bitmap.FromFile(newPath);
+                        var imageInfo = SixLabors.ImageSharp.Image.Identify(newPath);
 
-                        RelativeX = bitmap1.Width - RelativeX;
+                        RelativeX = imageInfo.Width - RelativeX;
                         ImageX = RelativeX;
-
-                        bitmap1.Dispose();
                     }
                 }
             }

--- a/Libraries/Chroma/ChromaFurniture.cs
+++ b/Libraries/Chroma/ChromaFurniture.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Xml;
 using KeplerCMS.Chroma.Extensions;
-using System.Drawing;
 using Color = SixLabors.ImageSharp.Color;
 using System;
 using Newtonsoft.Json;
@@ -465,30 +464,24 @@ namespace KeplerCMS.Chroma
                 }
 
 
-                using (Bitmap tempBitmap = canvas.ToBitmap())
+                if (CropImage && cropColours.Count > 0)
                 {
-                    if (CropImage && cropColours.Count > 0)
+                    // Crop the image
+                    using (var croppedImage = ImageUtil.Trim(canvas, cropColours.ToArray()))
                     {
-                        var temp = canvas.ToBitmap();
-
-                        // Crop the image
-                        using (Bitmap croppedBitmap = ImageUtil.TrimBitmap(tempBitmap, cropColours.ToArray()))
-                        {
-                            return RenderImage(croppedBitmap);
-                        }
-
+                        return RenderImage(croppedImage);
                     }
-                    else
-                    {
-                        return RenderImage(tempBitmap);
-                    }
+                }
+                else
+                {
+                    return RenderImage(canvas);
                 }
             }
         }
 
-        private byte[] RenderImage(Bitmap croppedBitmap)
+        private byte[] RenderImage(Image<Rgba32> croppedImage)
         {
-            return croppedBitmap.ToByteArray();
+            return croppedImage.ToByteArray();
         }
 
         private void TintImage(Image<Rgba32> image, string colourCode, byte alpha)

--- a/Libraries/Chroma/Extensions/ImageSharpExtensions.cs
+++ b/Libraries/Chroma/Extensions/ImageSharpExtensions.cs
@@ -1,44 +1,16 @@
-﻿using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
-using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using System.Drawing;
 using System.IO;
 
 namespace KeplerCMS.Chroma.Extensions
 {
     public static class ImageSharpExtensions
     {
-        public static System.Drawing.Bitmap ToBitmap<Rgba32>(this Image<Rgba32> image) where Rgba32 : unmanaged, IPixel<Rgba32>
-        {
-            using (var memoryStream = new MemoryStream())
-            {
-                var imageEncoder = Configuration.Default.ImageFormatsManager.GetEncoder(PngFormat.Instance);
-                image.Save(memoryStream, imageEncoder);
-
-                memoryStream.Seek(0, SeekOrigin.Begin);
-
-                return new System.Drawing.Bitmap(memoryStream);
-            }
-        }
-
-        public static Image<Rgba32> ToImageSharpImage<Rgba32>(this System.Drawing.Bitmap bitmap) where Rgba32 : unmanaged, IPixel<Rgba32>
-        {
-            using (var memoryStream = new MemoryStream())
-            {
-                bitmap.Save(memoryStream, System.Drawing.Imaging.ImageFormat.Png);
-
-                memoryStream.Seek(0, SeekOrigin.Begin);
-
-                return SixLabors.ImageSharp.Image.Load<Rgba32>(memoryStream);
-            }
-        }
-
-        public static byte[] ToByteArray(this Bitmap bitmap)
+        public static byte[] ToByteArray<TPixel>(this Image<TPixel> image) where TPixel : unmanaged, IPixel<TPixel>
         {
             using (MemoryStream ms = new MemoryStream())
             {
-                bitmap.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                image.SaveAsPng(ms);
 
                 return ms.ToArray();
             }

--- a/Libraries/Chroma/Extractor/FurniExtractor.cs
+++ b/Libraries/Chroma/Extractor/FurniExtractor.cs
@@ -3,9 +3,9 @@ using Flazzy;
 using Flazzy.Tags;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -95,10 +95,12 @@ namespace KeplerCMS.Chroma.Extractor
                         if (asset.Attributes.GetNamedItem("flipH") != null &&
                             asset.Attributes.GetNamedItem("flipH").InnerText == "1")
                         {
-                            var bitmap1 = (Bitmap)Bitmap.FromFile(newPath);
-                            bitmap1.RotateFlip(RotateFlipType.Rotate180FlipY);
-                            bitmap1.Save(newPath);
-                            bitmap1.Dispose();
+                            using (var flipped = SixLabors.ImageSharp.Image.Load<Rgba32>(newPath))
+                            {
+                                // Rotate180FlipY in GDI+ is equivalent to a horizontal mirror
+                                flipped.Mutate(x => x.Flip(FlipMode.Horizontal));
+                                flipped.Save(newPath);
+                            }
                         }
                     }
                 }

--- a/Libraries/Chroma/ImageUtil.cs
+++ b/Libraries/Chroma/ImageUtil.cs
@@ -1,24 +1,21 @@
-﻿using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
-using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
 using System;
-using System.Drawing;
-using System.IO;
 
 namespace KeplerCMS.Chroma
 {
     public class ImageUtil
     {
-        public static Bitmap TrimBitmap(Bitmap bmp)
+        public static Image<Rgba32> Trim(Image<Rgba32> image)
         {
-            int w = bmp.Width;
-            int h = bmp.Height;
+            int w = image.Width;
+            int h = image.Height;
 
             Func<int, bool> allWhiteRow = r =>
             {
                 for (int i = 0; i < w; ++i)
-                    if ((bmp.GetPixel(i, r).A != 0))
+                    if ((image[i, r].A != 0))
                         return false;
                 return true;
             };
@@ -26,7 +23,7 @@ namespace KeplerCMS.Chroma
             Func<int, bool> allWhiteColumn = c =>
             {
                 for (int i = 0; i < h; ++i)
-                    if ((bmp.GetPixel(c, i).A != 0))
+                    if ((image[c, i].A != 0))
                         return false;
                 return true;
             };
@@ -82,15 +79,7 @@ namespace KeplerCMS.Chroma
 
             try
             {
-                var target = new Bitmap(croppedWidth, croppedHeight);
-                using (Graphics g = Graphics.FromImage(target))
-                {
-                    g.DrawImage(bmp,
-                      new System.Drawing.RectangleF(0, 0, croppedWidth, croppedHeight),
-                      new System.Drawing.RectangleF(leftmost, topmost, croppedWidth, croppedHeight),
-                      GraphicsUnit.Pixel);
-                }
-                return target;
+                return image.Clone(ctx => ctx.Crop(new Rectangle(leftmost, topmost, croppedWidth, croppedHeight)));
             }
             catch (Exception ex)
             {
@@ -100,16 +89,16 @@ namespace KeplerCMS.Chroma
             }
         }
 
-        public static Bitmap TrimBitmap(Bitmap bmp, params Rgba32[] colors)
+        public static Image<Rgba32> Trim(Image<Rgba32> image, params Rgba32[] colors)
         {
-            int w = bmp.Width;
-            int h = bmp.Height;
+            int w = image.Width;
+            int h = image.Height;
 
 
             int topmost = 0;
             for (int row = 0; row < h; ++row)
             {
-                if (!allWhiteRow(bmp, row, colors))
+                if (!allWhiteRow(image, row, colors))
                     break;
                 topmost = row;
             }
@@ -117,7 +106,7 @@ namespace KeplerCMS.Chroma
             int bottommost = 0;
             for (int row = h - 1; row >= 0; --row)
             {
-                if (!allWhiteRow(bmp, row, colors))
+                if (!allWhiteRow(image, row, colors))
                     break;
                 bottommost = row;
             }
@@ -125,14 +114,14 @@ namespace KeplerCMS.Chroma
             int leftmost = 0, rightmost = 0;
             for (int col = 0; col < w; ++col)
             {
-                if (!allWhiteCol(bmp, col, colors))
+                if (!allWhiteCol(image, col, colors))
                     break;
                 leftmost = col;
             }
 
             for (int col = w - 1; col >= 0; --col)
             {
-                if (!allWhiteCol(bmp, col, colors))
+                if (!allWhiteCol(image, col, colors))
                     break;
                 rightmost = col;
             }
@@ -157,15 +146,7 @@ namespace KeplerCMS.Chroma
 
             try
             {
-                var target = new Bitmap(croppedWidth, croppedHeight);
-                using (Graphics g = Graphics.FromImage(target))
-                {
-                    g.DrawImage(bmp,
-                      new System.Drawing.RectangleF(0, 0, croppedWidth, croppedHeight),
-                      new System.Drawing.RectangleF(leftmost, topmost, croppedWidth, croppedHeight),
-                      GraphicsUnit.Pixel);
-                }
-                return target;
+                return image.Clone(ctx => ctx.Crop(new Rectangle(leftmost, topmost, croppedWidth, croppedHeight)));
             }
             catch (Exception ex)
             {
@@ -175,32 +156,13 @@ namespace KeplerCMS.Chroma
             }
         }
 
-        private static bool allWhiteRow(Bitmap bmp, int r, params Rgba32[] colors)
+        private static bool allWhiteRow(Image<Rgba32> image, int r, params Rgba32[] colors)
         {
-            int w = bmp.Width;
-            int h = bmp.Height;
+            int w = image.Width;
 
             for (int i = 0; i < w; ++i)
             {
-                var pixel = bmp.GetPixel(i, r);
-
-                if (!ColorEquals(colors, pixel)) 
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private static bool allWhiteCol(Bitmap bmp, int c, params Rgba32[] colors)
-        {
-            int w = bmp.Width;
-            int h = bmp.Height;
-
-            for (int i = 0; i < h; ++i)
-            {
-                var pixel = bmp.GetPixel(c, i);
+                var pixel = image[i, r];
 
                 if (!ColorEquals(colors, pixel))
                 {
@@ -211,7 +173,24 @@ namespace KeplerCMS.Chroma
             return true;
         }
 
-        private static bool ColorEquals(Rgba32[] colors, System.Drawing.Color pixel)
+        private static bool allWhiteCol(Image<Rgba32> image, int c, params Rgba32[] colors)
+        {
+            int h = image.Height;
+
+            for (int i = 0; i < h; ++i)
+            {
+                var pixel = image[c, i];
+
+                if (!ColorEquals(colors, pixel))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool ColorEquals(Rgba32[] colors, Rgba32 pixel)
         {
             foreach (var color in colors)
             {

--- a/Services/Implementations/UserService.cs
+++ b/Services/Implementations/UserService.cs
@@ -33,22 +33,18 @@ namespace KeplerCMS.Services.Implementations
         
         public async Task<List<SimpleUser>> GetOtherAccounts(int userId)
         {
-            // Get this user's v2 machine IDs (v1 IDs were truncated and prone to collisions)
-            var userMachineIds = await _context.UsersMachineIdLogs
-                .Where(m => m.UserId == userId && EF.Functions.Like(m.MachineId, "v2%"))
-                .Select(m => m.MachineId)
+            // Match other users sharing any of this user's v2 machine IDs (v1 IDs were
+            // truncated and prone to collisions). Correlated EXISTS instead of a string-list
+            // Contains, which MySql.EntityFrameworkCore 10 cannot translate to SQL.
+            var machineMatchUserIds = await _context.UsersMachineIdLogs
+                .Where(m => m.UserId != userId && _context.UsersMachineIdLogs.Any(um =>
+                    um.UserId == userId
+                    && EF.Functions.Like(um.MachineId, "v2%")
+                    && um.MachineId == m.MachineId))
+                .Select(m => m.UserId)
                 .Distinct()
+                .Take(100)
                 .ToListAsync();
-
-            // Match other users sharing any of these machine IDs
-            var machineMatchUserIds = userMachineIds.Any()
-                ? await _context.UsersMachineIdLogs
-                    .Where(m => userMachineIds.Contains(m.MachineId) && m.UserId != userId)
-                    .Select(m => m.UserId)
-                    .Distinct()
-                    .Take(100)
-                    .ToListAsync()
-                : new List<int>();
 
             if (!machineMatchUserIds.Any())
                 return new List<SimpleUser>();

--- a/Views/Shared/Containers/News.cshtml
+++ b/Views/Shared/Containers/News.cshtml
@@ -10,6 +10,9 @@
         @Html.Raw(link);
     }
 }
+@{
+    var promos = Model.Promos.Where(s => s.Hidden == false && s.IsScheduledVisible).OrderBy(s => s.Order).ToList();
+}
 <tr>
     <td colspan="3" style="padding-bottom: 3px;">
 
@@ -19,8 +22,6 @@
             <script type="text/javascript">
             var promoPages = [
                 @{
-                    
-                    var promos = Model.Promos.Where(s => s.Hidden == false && s.IsScheduledVisible).OrderBy(s => s.Order).ToList();
                     foreach (var promo in promos)
                     {
                         @:{

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,6 +8,9 @@
         }
     },
     "AllowedHosts": "*",
+    "Sentry": {
+        "Dsn": ""
+    },
     "DbResourceConfiguration": {
         "ResourceAccessMode": "DbResourceManager",
         "AddMissingResources": true,

--- a/runtimeconfig.template.json
+++ b/runtimeconfig.template.json
@@ -1,5 +1,0 @@
-{
-    "configProperties": {
-       "System.Drawing.EnableUnixSupport": true
-    }
- }


### PR DESCRIPTION
- Target net10.0; Microsoft packages to 10.0.x, MySql.EntityFrameworkCore 5.0.8 -> 10.0.7 (EF Core 10), Sentry.AspNetCore 6.6.0, RabbitMQ.Client 6.8.1 (stay on 6.x sync API), ImageSharp 3.1.12
- Replace all System.Drawing.Common usage with pure ImageSharp (GDI+ is Windows-only since .NET 7): rewrite TrimBitmap as ImageSharp Trim, map Rotate180FlipY to horizontal flip, drop Bitmap round-trips and the dead System.Drawing.EnableUnixSupport runtimeconfig switch
- Replace removed [MySqlCollation] attribute with UseCollation in DataContext; rewrite string-collection Contains in GetOtherAccounts as correlated EXISTS (untranslatable in MySQL EF provider 10)
- Dockerfile: .NET 10 images, ASPNETCORE_HTTP_PORTS=80 (base image defaults to 8080 since .NET 8), drop libgdiplus, Node 16 -> 22 LTS
- Disable static web asset precompression (SDK 10 emits .br/.gz that break Avatara/Chroma name-contains file scans on Linux)
- Sentry 6 throws on missing DSN: add explicit empty DSN default
- Hoist promos declaration in News.cshtml for .NET 10 Razor scoping

Verified: builds clean; Windows + Linux-container smoke tests against MariaDB 10.4.18 and RabbitMQ (front page, avatar/furni imaging paths render byte-identical PNGs cross-platform).

